### PR TITLE
env data from mesh

### DIFF
--- a/functions/meshTest.R
+++ b/functions/meshTest.R
@@ -21,4 +21,20 @@ meshTest <- function(meshList, regionGeometry, print = TRUE) {
     ggplot2::geom_sf(data = st_transform(regionGeometry, modelCRS), fill = "white") +
     inlabru::gg(mesh)
   if (print == TRUE) {print(meshPlot)}
+  return(mesh)
+}
+
+# inla mesh to sf
+inla.mesh_to_sf <- function(mesh){
+  # Extract mesh vertices and triangles
+  vertices <- mesh$loc
+  triangles <- mesh$graph$tv
+  # Create a list to store the polygons representing mesh triangles
+  tri_list <- lapply(1:nrow(triangles), function(i) {
+    list(rbind(vertices[triangles[i,], 1:2], vertices[triangles[i, 1], 1:2])) # Closing the triangle by adding the first vertex again
+  })
+  # Convert list of polygons to sf object
+  sf_mesh <- st_sf(geometry = st_sfc(lapply(tri_list, st_polygon), crs = mesh$crs$input))
+  # View the resulting sf object
+  return(sf_mesh)
 }

--- a/masterScript.R
+++ b/masterScript.R
@@ -40,6 +40,10 @@ source("pipeline/import/taxaImport.R")
 # Next we run the environmental import script, which brings in a set of rasters that apply to the region
 # we defined in the last step.
 
+myMesh <- list(cutoff = 11000, max.edge=c(42000, 49000), offset= 80000)
+mesh <- meshTest(myMesh, regionGeometry, print = F) %>% 
+  inla.mesh_to_sf()
+
 source("pipeline/import/environmentalImport.R")
 
 # Next we start on data processing, which adds extra information to our datasets.
@@ -51,7 +55,6 @@ source("pipeline/integration/speciesDataProcessing.R")
 # FAQ page of the shiny app. If you want to try out some potential meshes, you can do so using the
 # util file and editing the default list below.
 
-myMesh <- list(cutoff = 11000, max.edge=c(42000, 49000), offset= 80000)
 meshTest(myMesh, regionGeometry)
 
 # Once you've figured that out, you can start running the models. Remember that this script is the one that's 

--- a/pipeline/import/environmentalImport.R
+++ b/pipeline/import/environmentalImport.R
@@ -56,7 +56,11 @@ newproj <- "+proj=longlat +ellps=WGS84 +no_defs"
 ###--------------------###
 
 # define region with buffer 
-regionGeometry_buffer <- vect(st_buffer(regionGeometry, 20000))
+if(exists("mesh")){
+  regionGeometry_buffer <- vect(st_buffer(st_union(mesh), 20000))
+} else {
+  regionGeometry_buffer <- vect(st_buffer(regionGeometry, 20000))
+}
 
 parameterList <- list()
 


### PR DESCRIPTION
# Why have changes been made?

- inlabru returns warnings about interpolating NAs in environmental data, which can be reduced by downloading environmental data from the boundary of the mesh rather than regionGeometry

# What changes have been made?
- functions/meshTest.R - return inlabru mesh after plotting. add inla.mesh_to_sf function to convert inla mesh to SF object.
- masterScript.R - define mesh before environmental download. 
- pipeline/import/environmentalImport.R - if mesh is defined, then download environmental data using mesh for extent, otherwise use regionGeometry
