### PR TITLE
Store and use downloaded environmental data

### DIFF
--- a/functions/is.subset.r
+++ b/functions/is.subset.r
@@ -1,0 +1,43 @@
+#' Check if the extent of one object encompasses the extent of another
+#'
+#' @param x a `SpatRaster`, `SpatVector`, or `sf` object
+#' @param y a `SpatRaster`, `SpatVector`, or `sf` object
+#' @return TRUE if the extent of x is subset y, otherwise FALSE
+#' @importFrom terra ext
+#' @importFrom sf st_bbox
+is.subset <- function(x, y){ 
+  # Function to get extent for both terra and sf objects
+  vectorize <- function(obj) {
+    if (inherits(obj, "sf")) {
+      return(obj)
+    } else if (inherits(obj, "SpatVector")) {
+      return(st_as_sf(obj))
+    } else if (inherits(obj, "SpatRaster")) {
+      return(st_as_sf(as.polygons(obj, extent = T)))
+    } else {
+      stop("Invalid input: x and y should be either SpatRaster, SpatVector, or sf objects.")
+    }
+  }
+  # vectorise
+  x <- vectorize(x)
+  y <- vectorize(y)
+  # check valid crs
+  if(is.na(st_crs(x)) & is.na(st_crs(x))){
+    warning("CRS not defined for x or y; assuming same CRS for both.")
+  } else if (is.na(st_crs(x))){
+    warning("CRS not defined for x; assuming same CRS as y.")
+    x <- st_transform(x, st_crs(y))
+  } else if (is.na(st_crs(y))){
+    warning("CRS not defined for y; assuming same CRS as x.")
+    y <- st_transform(y, st_crs(x))
+  } else if(st_crs(x) != st_crs(y)) {
+    # match projections
+    x <- st_transform(x, st_crs(y))
+  }
+  # calculate area of x and check overlap
+  area_x <- sum(st_area(x))
+  # due to rounding, allow for difference of 0.0001 %
+  return(
+    as.numeric(abs((sum(st_area(x)) - sum(st_area(st_intersection(x, y))))/sum(st_area(x)))) < 1e-6
+  )
+}

--- a/pipeline/import/environmentalImport.R
+++ b/pipeline/import/environmentalImport.R
@@ -11,6 +11,7 @@ library(raster)
 library(terra)
 library(sf)
 library(fasterize)
+library(digest)  # create hash of raster CRS and projection for saving
 
 # Import local functions
 sapply(list.files("functions", full.names = TRUE), source)
@@ -60,7 +61,7 @@ regionGeometry_buffer <- vect(st_buffer(regionGeometry, 20000))
 
 parameterList <- list()
 
-for (parameter in 1:length(selectedParameters)) {
+for (parameter in seq_along(selectedParameters)) {
   focalParameter <- selectedParameters[parameter]
   external <- parameters$external[parameters$parameters == focalParameter]
   
@@ -68,20 +69,61 @@ for (parameter in 1:length(selectedParameters)) {
     rasterisedVersion <- rast(paste0("data/external/environmentalCovariates/",focalParameter, ".tiff"))
   } else {
     dataSource <- parameters$dataSource[parameters$parameters == focalParameter]
-    source(paste0("pipeline/import/utils/defineEnvSource.R"))
+    # check if data has already been downloaded
+    raster_found <- FALSE
+    if(dir.exists(paste0("data/temp/", dataSource))){
+      ## List all files in the directory that match the parameter
+      file_list <- list.files(path = paste0("data/temp/", dataSource), 
+                              pattern = paste0(focalParameter, "_.*\\.tiff$"), 
+                              full.names = TRUE)
+      # Check files
+      for (file in file_list) {
+        rast <- rast(file)
+        if (is.subset(regionGeometry_buffer, rast)) {
+          rasterisedVersion <- rast
+          raster_found <- TRUE
+          cat("Raster encompassing region found and imported successfully!\n")
+          break
+        } 
+      }   
+    } else {
+      dir.create(paste0("data/temp/", dataSource))
+    }
+    if (!raster_found) {
+      # download file
+      source(paste0("pipeline/import/utils/defineEnvSource.R"))
+      # get info to save
+      info <- crs(rasterisedVersion, describe = T)
+      if(!is.na(info$authority)){
+        ext <- ext(rasterisedVersion)
+        info <- sprintf("%s%s_X%s_%s_Y%s_%s",
+                        info$authority, info$code, 
+                        ext[1], ext[2], ext[3], ext[4])
+      } else {
+        info <- digest(list(crs(rasterisedVersion), ext(rasterisedVersion)))
+      }
+      #  Construct the filename and save with raster information
+      file_path <- sprintf("data/temp/%s/%s_%s.tiff",
+                           dataSource,focalParameter, info)
+      x <- rasterisedVersion
+      if(!file.exists(file_path)){
+        writeRaster(x, filename = file_path, overwrite = TRUE)
+      }
+    }
   }
   parameterList[[parameter]] <- rasterisedVersion
 }
 
 
-# Import and correctly project all covariate data selected in the csv file
+# crop each covariate to extent of regionGeometry_buffer
 parametersCropped <- lapply(parameterList, FUN = function(x) {
   scale(
     crop(x,
-         project(regionGeometry_buffer, x), 
+         project(as.polygons(regionGeometry_buffer, extent = T), x), 
          snap = "out", mask = T)
   )
 })
+
 # project all rasters to the one with the highest resolution and combine 
 reference <- which.min(sapply(parametersCropped, res)[1,])
 parametersCropped <- do.call(c, 


### PR DESCRIPTION
# Why have changes been made?

- environmental data is downloaded each time code is run, necessarily using up time and computation resources.

# What changes have been made?

- functions/is.subset.r - create function that determines if one spatial object is a subset of a second spatial object. Used to determine if existing downloaded environmental data encapsulates area of interest to use instead of downloading new data.
- pipeline/import/environmentalImport.R: 
1. use seq_along(selectedParameters) for loop
2. store downloaded environmental data in temp folder (with coded information on extent/resolution) and use these if they encompass focal region/mesh.
3. Remove cropping of environmental data (doesn't increase computation time, but may require redownloading same data in the future).