### PR TITLE
debug get_worldclim.R

### DIFF
--- a/functions/buffer.SpatExtent.R
+++ b/functions/buffer.SpatExtent.R
@@ -1,0 +1,49 @@
+#' buffer_ext
+#'
+#' @param x spatial extent as returned by SpatRaster
+#' @param portion Description of argument
+#' @param distance Description of argument
+#'
+#' @return Description of the return value
+#'
+#' @export
+#' 
+library(terra)
+
+# Custom buffer function for SpatExtent class
+buffer.SpatExtent <- function(x, portion = NA, distance = NA, lonlat = NA) {
+  # Perform the desired operations for SpatExtent objects
+  # Replace this with your custom implementation
+  message("Custom buffer function for SpatExtent called.")
+  
+  if(is.na(lonlat) | !is.logical(lonlat)) stop("Error: lonlat should be TRUE or FALSE")
+  if(is.na(portion) & is.na(distance)) stop("Error: must provide either portion or dincance.")
+  # Load required packages
+  if (!requireNamespace("terra", quietly = TRUE)) {
+    stop("Package 'terra' is required but not installed.")
+  }
+  if (!requireNamespace("dplyr", quietly = TRUE)) {
+    stop("Package 'dplyr' is required but not installed.")
+  }
+  
+  if(is.na(distance) & is.numeric(portion))
+    distance <- matrix(c(mean(x[1:2]), x[3],
+             mean(x[1:2]), x[4],
+             x[1], mean(x[3:4]),
+             x[2], mean(x[3:4])), 
+           ncol = 2, byrow = T) %>% 
+      terra::distance(lonlat = lonlat, 
+                      sequential = T) %>% 
+      {.[c(2,4)]*portion} %>% 
+      max()
+  
+  # add distance to extent
+  if(lonlat)
+    buffer(vect(x, crs = "epsg:4326"), distance) %>% ext 
+  else
+    buffer(vect(x), distance) %>% ext 
+    
+}
+
+# Register the custom buffer function as an S3 method
+setMethod("buffer", signature(x = "SpatExtent"), buffer.SpatExtent)

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -25,8 +25,6 @@ if (dataSource == "geonorge") {
   
 ### 2. worldclim ####  
 } else if (dataSource == "worldclim") {
-  # Set extent for download
-  regionExtent <- ext(regionGeometry_buffer)
   
   print(paste0("Downloading ", focalParameter," from ", dataSource))
   
@@ -45,7 +43,7 @@ if (dataSource == "geonorge") {
   var <- recode_vector[focalParameter]
   
   # download
-  annualStack <- get_worldclim(regionExtent, var, 0.5)
+  annualStack <- get_worldclim(regionGeometry_buffer, var, 0.5)
   
   # average
   rasterisedVersion <- mean(annualStack)


### PR DESCRIPTION

# Why have changes been made?

- error caused when using mesh for downloading worldclim (wrong CRS assumed). Additionally, added missing custom buffer() function that get_worldclim.R relied on.
 
# What changes have been made?
- functions/buffer.SpatExtent.R -  add missing custom buffer function (to buffer SpatExtent by distance or proportion)
- functions/get_worldclim.R - add check/warning when coords is SpatExt is wgs84 lat/lon CRS
- functions/get_worldclim.R - add ability to use SpatRaster for worldclim download.
- pipeline/import/utils/defineEnvSource.R - download directly using regionGeometry_buffer instead of first converting to SpatExtent
