### PR TITLE
R debug 2023 11 08

### DIFF
--- a/functions/is.subset.r
+++ b/functions/is.subset.r
@@ -36,8 +36,8 @@ is.subset <- function(x, y){
   }
   # calculate area of x and check overlap
   area_x <- sum(st_area(x))
-  # due to rounding, allow for difference of 0.0001 %
+  # due to rounding, allow for difference of 0.01 %
   return(
-    as.numeric(abs((sum(st_area(x)) - sum(st_area(st_intersection(x, y))))/sum(st_area(x)))) < 1e-6
+    as.numeric(abs((sum(st_area(x)) - sum(st_area(st_intersection(x, y))))/sum(st_area(x)))) < 1e-4
   )
 }

--- a/functions/meshTest.R
+++ b/functions/meshTest.R
@@ -12,13 +12,13 @@
 
 meshTest <- function(meshList, regionGeometry, print = TRUE) {
   modelCRS <- "Proj.4 +proj=utm +zone=32 +datum=WGS84 +units=m +no_defs +type=crs" # 32632  # epsg code corresponding to same projection
-  mesh <- INLA::inla.mesh.2d(boundary = inlabru::fm_as_inla_mesh_segment(st_transform(regionGeometry, modelCRS)),
+  mesh <- INLA::inla.mesh.2d(boundary = inlabru::fm_as_inla_mesh_segment(sf::st_transform(regionGeometry, modelCRS)),
                              crs = inlabru::fm_crs(modelCRS),
                              cutoff= meshList$cutoff, 
                              max.edge=meshList$max.edge, 
                              offset= meshList$offset)
   meshPlot <- ggplot2::ggplot()+
-    ggplot2::geom_sf(data = st_transform(regionGeometry, modelCRS), fill = "white") +
+    ggplot2::geom_sf(data = sf::st_transform(regionGeometry, modelCRS), fill = "white") +
     inlabru::gg(mesh)
   if (print == TRUE) {print(meshPlot)}
   return(mesh)

--- a/functions/speciesRichnessConverter.R
+++ b/functions/speciesRichnessConverter.R
@@ -28,8 +28,8 @@ speciesRichnessConverter <- function(regionGeometry, presenceData, blankRaster) 
                        fun = n_unique)
     ifel(is.na(rs1), 0, rs1) 
   }) |> 
-    setNames(focalTaxa) |> # assign names
     rast() |> # combine into multi-layer raster
+    setNames(focalTaxa) |> # assign names
     terra::crop(regionGeometry_buffer, snap = "out", mask = TRUE)  # crop
 
   # convert to sf data.frame

--- a/pipeline/import/environmentalImport.R
+++ b/pipeline/import/environmentalImport.R
@@ -123,7 +123,7 @@ for (parameter in seq_along(selectedParameters)) {
 parametersCropped <- lapply(parameterList, FUN = function(x) {
   scale(
     crop(x,
-         project(as.polygons(regionGeometry_buffer, extent = T), x), 
+         terra::project(as.polygons(regionGeometry_buffer, extent = T), x), 
          snap = "out", mask = T)
   )
 })
@@ -132,7 +132,7 @@ parametersCropped <- lapply(parameterList, FUN = function(x) {
 reference <- which.min(sapply(parametersCropped, res)[1,])
 parametersCropped <- do.call(c, 
                              lapply(parametersCropped, function(x){
-                               project(x, parametersCropped[[reference]])
+                               terra::project(x, parametersCropped[[reference]])
                              }))
 # assign names
 names(parametersCropped) <- selectedParameters

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -52,3 +52,7 @@ if (dataSource == "geonorge") {
 } else if (dataSource == "ssb") {
     rasterisedVersion <- get_ssb(focalParameter, resolution = "250")
 }
+
+### merge with requested download area to make missing data explicit
+rasterisedVersion <- extend(rasterisedVersion, terra::project(regionGeometry_buffer, rasterisedVersion), snap = "out")
+


### PR DESCRIPTION
# Why have changes been made?

- wrong package may be used depending on code execution (namely sf and terra). 
- ssb data downloaded repeatedly because its extent does not encompass full regionGeometry_buffer.
- metadataProduction.Rmd fails to extract raster layer name because of incorrect order of name assignment in speciesDataProcessing.R

# What changes have been made?
- functions/meshTest.R & pipeline/import/environmentalImport.R - specify terra and sf packages
- functions/speciesRichnessConverter.R - reorder name assignment in speciesRichnessConverter
- functions/is.subset.r - relax is.subset from 0.0001% overlap to 0.01% overlap
- pipeline/import/utils/defineEnvSource.R - explicitly add NA to area outside of region downloaded up to the extent of regionGeometry_buffer by extending raster to encompass regionGeometry_buffer used to specify data download.
