### PR TITLE
wait for gbif then download

### DIFF
--- a/functions/getDownloadKey.R
+++ b/functions/getDownloadKey.R
@@ -34,7 +34,6 @@ getDownloadKey <- function(taxa, regionGeometry) {
     pred("geometry", st_as_text(regionGeometry[[1]])),
     pred_lte("coordinateUncertaintyInMeters", 100),
     type = "and"
-  ) %>% 
-    occ_download_meta
+  ) 
   return(download_key)
 }

--- a/masterScript.R
+++ b/masterScript.R
@@ -36,6 +36,7 @@ region <- "Norway"
 # FALSE here.
 
 scheduledDownload <- TRUE
+wait_for_gbif <- TRUE
 source("pipeline/import/taxaImport.R")
 
 # Next we run the environmental import script, which brings in a set of rasters that apply to the region

--- a/pipeline/import/taxaImport.R
+++ b/pipeline/import/taxaImport.R
@@ -73,13 +73,22 @@ if ("metadataSummary.csv" %in% list.files("data/external")) {
 if (scheduledDownload == TRUE) {
   
   # Get download key/initialise GBIF download
-  if (!file.exists(paste0(folderName, "/downloadKey.RDS"))) {
-    downloadKey <- getDownloadKey(focalTaxon$key, regionGeometry)
-    saveRDS(downloadKey, file = paste0(folderName, "/downloadKey.RDS"))
-    stop(paste0("Download key has been created and your download is being prepared. View the download at https://www.gbif.org/occurrence/download/", 
-                downloadKey$key, ". Come back and start the download in 5-30 minutes."))
-  } else {
+  if (file.exists(paste0(folderName, "/downloadKey.RDS"))) {
     downloadKey <- readRDS(paste0(folderName, "/downloadKey.RDS"))
+  } else {
+    downloadKey <- getDownloadKey(focalTaxon$key, regionGeometry)
+    if(wait_for_gbif){
+      message("Download key has been created and will download once it is ready (5-30 minutes). ",
+              "View the download status at https://www.gbif.org/occurrence/download/", 
+              downloadKey)
+      downloadKey <- occ_download_wait(downloadKey, curlopts = list(), quiet = FALSE)
+      saveRDS(downloadKey, file = paste0(folderName, "/downloadKey.RDS"))
+    } else {
+      downloadKey <- occ_download_meta(downloadKey) 
+      saveRDS(downloadKey, file = paste0(folderName, "/downloadKey.RDS"))
+      stop(paste0("Download key has been created and your download is being prepared. View the download at https://www.gbif.org/occurrence/download/",
+                  downloadKey$key, ". Come back and start the download in 5-30 minutes."))
+    }
   }
   
   # Start GBIF Download  


### PR DESCRIPTION
# Why have changes been made?

- add option to wait and auto-download gbif download instead of stopping taxaImport.R script.

# What changes have been made?

- functions/getDownloadKey.R - remove occ_download_meta to only return download key
- masterScript.R - add specification for whether to wait/autodownload gbif data when it is ready
- pipeline/import/taxaImport.R - use occ_download_wait() to wait for download to be ready before proceeding. for clarity, first check for and import existing downloadKey.RDS, otherwise define/save downloadKey.RDS. 