### PR TITLE
Check existing gbif creds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .Rhistory
 .RData
 .Ruserdata
+.Renviron
 
 /ignored/*
 

--- a/functions/getDownloadKey.R
+++ b/functions/getDownloadKey.R
@@ -10,11 +10,26 @@
 #'
 
 getDownloadKey <- function(taxa, regionGeometry) {
+  # Check if credentials are stored in .Renviron
+  gbif_user <- Sys.getenv("gbif_user", "")
+  gbif_email <- Sys.getenv("gbif_email", "")
+  gbif_pwd <- Sys.getenv("gbif_pwd", "")
   
-  # Log in to GBIF
-  options(gbif_user=rstudioapi::askForPassword("my gbif username"))
-  options(gbif_email=rstudioapi::askForPassword("my registred gbif e-mail"))
-  options(gbif_pwd=rstudioapi::askForPassword("my gbif password"))
+  # If not found in .Renviron, check in options, or ask the user
+  if (gbif_user == "") {
+    gbif_user <- getOption("gbif_user", rstudioapi::askForPassword("my GBIF username"))
+  }
+  if (gbif_email == "") {
+    gbif_email <- getOption("gbif_email", rstudioapi::askForPassword("my registered GBIF e-mail"))
+  }
+  if (gbif_pwd == "") {
+    gbif_pwd <- getOption("gbif_pwd", rstudioapi::askForPassword("my GBIF password"))
+  }
+  
+  # Set the credentials in options (if they were asked from the user)
+  options(gbif_user=gbif_user)
+  options(gbif_email=gbif_email)
+  options(gbif_pwd=gbif_pwd)
   
   if (!is.numeric(taxa)) {
     keys <- as.integer()


### PR DESCRIPTION
# Why have changes been made?

allow for definition of GBIF credentials (and potentially for other sources) using .Renviron file so you do not need to reenter in new R sessions.

# What changes have been made?

- .gitignore - added .Renviron to .gitignore to not upload private information.
- functions/getDownloadKey.R - check/use gbif credentials from .Renviron, otherwise ask for missing credentials using rstudioapi::askForPassword
