### PR TITLE
Species processing clean up

### DIFF
--- a/data/external/metadataSummary.csv
+++ b/data/external/metadataSummary.csv
@@ -72,7 +72,7 @@ d7e36e03-340d-4cba-904c-a2a3e662d3cd,Ecofact,presenceOnly
 0f061eff-6854-4bb3-abe2-acb184ea3ab7,"Bryophyte herbarium, The Arctic University Museum of Norway (TROM)",presenceOnly
 ec1922d6-292e-4443-8bae-deba1092856b,"Bryophyte herbarium, UiB",presenceOnly
 9678e1a6-b1c4-4e86-9d26-ebb169338655,"Vascular plants in power line clearings and the nearby forest, southeast Norway",fieldNotesEvent
-0db86a4c-5b10-4a39-b81d-15e1525bb27f,"Presence data for vascular plant, bryophyte and lichen species in 100 vegetation plots (each 1 m2) from 32 shell-beds at Akerøya, Hvaler, SE Norway",NA
+0db86a4c-5b10-4a39-b81d-15e1525bb27f,"Presence data for vascular plant, bryophyte and lichen species in 100 vegetation plots (each 1 m2) from 32 shell-beds at Akerøya, Hvaler, SE Norway",fieldNotes
 53f2cda4-a2fd-49f0-b3e5-0782c9770e7c,Norwegian specimens stored in Herb. Klepsland (pre 2022),presenceOnly
 5113877b-3da2-4ac2-a7cb-58f67da66228,"Monitoring data of natural and man-made semi-natural meadows in and around Oslo, Norway 2018-2021",fieldNotesEvent
 2ce085b1-f05e-4bb9-8a3b-0ae583f3a58d,Bryophytes from a study of primary producer traits across an altitudinal gradient in alpine Finse,fieldNotesEvent
@@ -93,7 +93,7 @@ cf999616-58f0-43af-8dba-164c0323f19d,Lichens from a study of primary producer tr
 8904724a-8de2-41cf-848f-e6af7a80a2d3,"Red list project inventory, lichens",fieldNotesOslo
 14d5676a-2c54-4f94-9023-1e8dcd822aa0,Pl@ntNet automatically identified occurrences,presenceOnly
 9678e1a6-b1c4-4e86-9d26-ebb169338655,"Vascular plants in power line clearings and the nearby forest, southeast Norway",fieldNotesEvent
-ae77cf87-0f7f-4a08-91cc-5d55230fb421,Overvåking av åpen grunnlendt kalkmark i Oslofjordområdet,NA
+ae77cf87-0f7f-4a08-91cc-5d55230fb421,Overvåking av åpen grunnlendt kalkmark i Oslofjordområdet,fieldNotes
 78ab5416-bf56-4714-a2bf-096b16f0e1d8,Effects of vegetation clearing on vascular plants in power line clearings southeast Norway,fieldNotesEvent
 6bbcb71c-42e7-40e7-bd02-b66d4e9a5c6e,"Vegetation data with and without experimental warming, alpine Finse 2000, 2004, 2011",fieldNotesEvent
 3cf0df27-6416-46a2-ad5e-7d970e5d1a19,Stabbetorp - Floristiske registreringer 2016,presenceOnly

--- a/functions/findGBIFName.R
+++ b/functions/findGBIFName.R
@@ -9,6 +9,10 @@
 #' 
 
 findGBIFName <- function(scientificName) {
+  
+  if (str_detect(substr(scientificName,1,1),"[[:lower:]]")) {
+    substr(scientificName,1,1) <- toupper(substr(scientificName,1,1))
+  }
   speciesNameTable <- as.data.frame(rgbif::name_backbone(scientificName))
   if ("species" %in% colnames(speciesNameTable)) {
     acceptedName <- speciesNameTable[1, "scientificName"]

--- a/functions/processFieldNotes.R
+++ b/functions/processFieldNotes.R
@@ -64,7 +64,7 @@ processFieldNotes <- function(focalEndpoint, tempFolderName, datasetName, region
     distinct()
   
   # Start constructing table
-  eventTable <- expand.grid(scientificName = surveyedSpecies, eventID = unique(eventLocationsSF$eventID))
+  eventTable <- expand.grid(scientificName = speciesLegend$surveyedSpecies, eventID = unique(eventLocationsSF$eventID))
   eventTable <- merge(eventTable, eventDates, all.x = TRUE, by = "eventID")
   
   # Create an individual count 

--- a/functions/processFieldNotes.R
+++ b/functions/processFieldNotes.R
@@ -21,19 +21,26 @@ processFieldNotes <- function(focalEndpoint, tempFolderName, datasetName, region
   # Get the relevant endpoint
   
   # Download and unzip file in temp folder
-  options(timeout=100)
+  #options(timeout=100)
   download.file(focalEndpoint, paste0(tempFolderName,"/", datasetName ,".zip"), mode = "wb")
   unzip(paste0(tempFolderName,"/", datasetName ,".zip"), exdir = paste0(tempFolderName,"/",  datasetName))
   
   # Load in occurrence data
   occurrence <- read.delim(paste0(tempFolderName,"/", datasetName ,"/occurrence.txt"))
   
-  
+  # Create surveyed species
   surveyedSpecies <- unique(occurrence$scientificName)
-  occurrence$eventID <- sapply(occurrence$id, FUN = function(x) {
-    strsplit(x, "[/]")[[1]][1]
+  
+  # Create eventID
+  # 1. Check for eventID 
+  if (!("eventID" %in% colnames(occurrence))) {
+    # 2. If no eventDate, create eventDate
+    if(length(unique(occurrence$eventDate)) == 1 &  is.na(unique(occurrence$eventDate))) {
+      occurrence$eventDate <- paste(occurrence$year, occurrence$month, occurrence$day, sep = "-")
+    }
+    occurrence$eventID <- paste(occurrence$locality, occurrence$eventDate, sep = "-")
   }
-  )
+  
   
   # Buold a species table
   speciesLegend <- data.frame(surveyedSpecies = surveyedSpecies, 
@@ -43,14 +50,13 @@ processFieldNotes <- function(focalEndpoint, tempFolderName, datasetName, region
   
   # Find only eventIDs within our regionGeometry
   eventLocations <- occurrence %>%
-    filter(!is.na(decimalLatitude) & !is.na(decimalLongitude)) %>%
-    dplyr::select(decimalLatitude, decimalLongitude, eventID, coordinateUncertaintyInMeters) %>%
+    filter(!is.na(decimalLatitude) & !is.na(decimalLongitude) & coordinateUncertaintyInMeters <= 100) %>%
+    dplyr::select(decimalLatitude, decimalLongitude, eventID) %>%
     distinct()
   eventLocationsSF <- st_as_sf(eventLocations,                         
                                coords = c("decimalLongitude", "decimalLatitude"),
                                crs = "+proj=longlat +ellps=WGS84")
-  eventLocationsSF <- st_intersection(eventLocationsSF, regionGeometry) %>%
-    filter(coordinateUncertaintyInMeters <= 100)
+  eventLocationsSF <- st_intersection(eventLocationsSF, regionGeometry)
   
   # Get a dates table to match years to events
   eventDates <- occurrence %>%
@@ -61,10 +67,13 @@ processFieldNotes <- function(focalEndpoint, tempFolderName, datasetName, region
   eventTable <- expand.grid(scientificName = surveyedSpecies, eventID = unique(eventLocationsSF$eventID))
   eventTable <- merge(eventTable, eventDates, all.x = TRUE, by = "eventID")
   
+  # Create an individual count 
+  occurrence$individualCount <- 1
+  
   # Add in occurrence data, an NA in coordinateUncertainy column means the species was NOT found in the survey
-  eventTableWithOccurrences <- merge(eventTable, occurrence[,c("eventID", "scientificName", "coordinateUncertaintyInMeters")], all.x = TRUE,
+  eventTableWithOccurrences <- merge(eventTable, occurrence[,c("eventID", "scientificName", "individualCount")], all.x = TRUE,
                                      by.x = c("scientificName", "eventID"), by.y = c("scientificName", "eventID"))
-  eventTableWithOccurrences$individualCount <- ifelse(!is.na(eventTableWithOccurrences$coordinateUncertaintyInMeters), 1, 0)
+  eventTableWithOccurrences$individualCount[is.na(eventTableWithOccurrences$individualCount)] <- 0
   eventTableWithOccurrences$geometry <- eventLocationsSF$geometry[match(eventTableWithOccurrences$eventID, eventLocationsSF$eventID)]
   eventTableWithOccurrences$acceptedScientificName <- speciesLegend$acceptedScientificName[match(eventTableWithOccurrences$scientificName, speciesLegend$surveyedSpecies)]
   

--- a/functions/processFieldNotesEvent.R
+++ b/functions/processFieldNotesEvent.R
@@ -71,7 +71,7 @@ processFieldNotesEvent <- function(focalEndpoint, tempFolderName, datasetName, r
     filter(!is.na(taxonKey))
   
   # Create table with all data combinations that we can match to
-  eventTable <- expand.grid(species = surveyedSpecies, eventID = unique(eventLocationsSF$eventID))
+  eventTable <- expand.grid(species = speciesLegend$surveyedSpecies, eventID = unique(eventLocationsSF$eventID))
   eventTable <- merge(eventTable, eventDates, all.x = TRUE, by = "eventID")
   
   # Create an individual count 

--- a/functions/processFieldNotesOslo.R
+++ b/functions/processFieldNotesOslo.R
@@ -58,7 +58,7 @@ processFieldNotesOslo <- function(focalEndpoint, tempFolderName, datasetName, re
     distinct()
   
   # Start constructing table
-  eventTable <- expand.grid(scientificName = surveyedSpecies, eventID = unique(eventLocationsSF$eventID))
+  eventTable <- expand.grid(scientificName = speciesLegend$surveyedSpecies, eventID = unique(eventLocationsSF$eventID))
   eventTable <- merge(eventTable, eventDates, all.x = TRUE, by = "eventID")
   
   # Create an individual count 

--- a/functions/processFieldNotesOslo.R
+++ b/functions/processFieldNotesOslo.R
@@ -1,0 +1,86 @@
+
+#' @title \emph{processFieldNotesOslo}: Turns a presence only dataset into a presence absence dataset for surveyed data.
+
+#' @description Some datasets have been reduced by GBIF to presence-only, despite the fact they are in fact presence-absence datastes. This function downloads these datasets directly from the source and adds the absences back in.
+#'
+#' @param focalEndpoint An endpoint through which the original dataset can be downloaded.
+#' @param tempFolderName A directory in which to save the data downloaded directly from the source.
+#' @param datasetName The name of the dataset to be downloaded.
+#' @param regionGeometry An sf object encompassing our region of study, as produced by defineRegion.
+#' @param focalTaxon A dataframe giving the key and names of each taxonomic group we are downloading.
+#' 
+#' @return A new dataset with absences added back in.
+#'
+#' @import sf
+#' 
+#' 
+#' 
+processFieldNotesOslo <- function(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon) {
+  
+  
+  # Get the relevant endpoint
+  
+  # Download and unzip file in temp folder
+  #options(timeout=100)
+  download.file(focalEndpoint, paste0(tempFolderName,"/", datasetName ,".zip"), mode = "wb")
+  unzip(paste0(tempFolderName,"/", datasetName ,".zip"), exdir = paste0(tempFolderName,"/",  datasetName))
+  
+  # Load in occurrence data
+  occurrence <- read.delim(paste0(tempFolderName,"/", datasetName ,"/occurrence.txt"))
+  
+  # Create surveyed species and eventID
+  surveyedSpecies <- unique(occurrence$scientificName)
+  occurrence$eventID <- sapply(occurrence$id, FUN = function(x) {
+    strsplit(x, "[/]")[[1]][1]
+  }
+  )
+  
+  # Buold a species table
+  speciesLegend <- data.frame(surveyedSpecies = surveyedSpecies, 
+                              acceptedScientificName = sapply(surveyedSpecies, FUN = findGBIFName),
+                              taxonKey = sapply(surveyedSpecies, FUN = function(x) {taxaCheck(x, focalTaxon$key)})) %>%
+    filter(!is.na(taxonKey))
+  
+  # Find only eventIDs within our regionGeometry
+  eventLocations <- occurrence %>%
+    filter(!is.na(decimalLatitude) & !is.na(decimalLongitude)) %>%
+    dplyr::select(decimalLatitude, decimalLongitude, eventID, coordinateUncertaintyInMeters) %>%
+    distinct()
+  eventLocationsSF <- st_as_sf(eventLocations,                         
+                               coords = c("decimalLongitude", "decimalLatitude"),
+                               crs = "+proj=longlat +ellps=WGS84")
+  eventLocationsSF <- st_intersection(eventLocationsSF, regionGeometry) %>%
+    filter(coordinateUncertaintyInMeters <= 100)
+  
+  # Get a dates table to match years to events
+  eventDates <- occurrence %>%
+    dplyr::select(year, eventID) %>%
+    distinct()
+  
+  # Start constructing table
+  eventTable <- expand.grid(scientificName = surveyedSpecies, eventID = unique(eventLocationsSF$eventID))
+  eventTable <- merge(eventTable, eventDates, all.x = TRUE, by = "eventID")
+  
+  # Create an individual count 
+  occurrence$individualCount <- 1
+  
+  # Add in occurrence data, an NA in coordinateUncertainy column means the species was NOT found in the survey
+  eventTableWithOccurrences <- merge(eventTable, occurrence[,c("eventID", "scientificName", "individualCount")], all.x = TRUE,
+                                     by.x = c("scientificName", "eventID"), by.y = c("scientificName", "eventID"))
+  eventTableWithOccurrences$individualCount[is.na(eventTableWithOccurrences$individualCount)] <- 0
+  eventTableWithOccurrences$geometry <- eventLocationsSF$geometry[match(eventTableWithOccurrences$eventID, eventLocationsSF$eventID)]
+  eventTableWithOccurrences$acceptedScientificName <- speciesLegend$acceptedScientificName[match(eventTableWithOccurrences$scientificName, speciesLegend$surveyedSpecies)]
+  
+  # Add final columns
+  eventTableWithOccurrences$dataType <- "PA"
+  eventTableWithOccurrences$taxonKey <- speciesLegend$taxonKey[match(eventTableWithOccurrences$acceptedScientificName, speciesLegend$acceptedScientificName)]
+  eventTableWithOccurrences$taxa <- focalTaxon$taxa[match(eventTableWithOccurrences$taxonKey, focalTaxon$key)]
+  
+  # New dataset is ready!
+  newDataset <- st_as_sf(eventTableWithOccurrences,          
+                         crs = "+proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0")
+  newDataset <- newDataset %>%
+    dplyr::select(acceptedScientificName, individualCount, geometry, dataType, taxa, year) %>%
+    filter(!is.na(acceptedScientificName))
+  return(newDataset)
+}

--- a/functions/taxaCheck.R
+++ b/functions/taxaCheck.R
@@ -11,6 +11,10 @@
 #'
 taxaCheck <- function(scientificName, taxaKeys) {
   
+  if (str_detect(substr(scientificName,1,1),"[[:lower:]]")) {
+    substr(scientificName,1,1) <- toupper(substr(scientificName,1,1))
+  }
+  
   speciesNameTable <- as.data.frame(rgbif::name_backbone(scientificName))
   
   if (speciesNameTable$matchType == "NONE") {

--- a/pipeline/integration/speciesDataProcessing.R
+++ b/pipeline/integration/speciesDataProcessing.R
@@ -23,9 +23,6 @@ if (!exists("dateAccessed")) {
   dateAccessed <- as.character(Sys.Date())
 }
 
-# Import taxa list
-focalTaxon <- read.csv("data/external/focalTaxa.csv")
-focalTaxon <- focalTaxon[focalTaxon$include,]
 
 # Import datasets
 folderName <- paste0("data/run_", dateAccessed)
@@ -35,6 +32,10 @@ speciesData <- speciesDataList[["species"]]
 redList <- speciesDataList[["redList"]]
 metadata <- speciesDataList$metadata$metadata
 regionGeometry <- readRDS(paste0(folderName, "/regionGeometry.RDS"))
+
+# Import taxa list
+focalTaxon <- read.csv(paste0(folderName, "/focalTaxa.csv"), header = T)
+focalTaxon <- focalTaxon[focalTaxon$include,]
 
 # Import local functions
 sapply(list.files("functions", full.names = TRUE), source)
@@ -72,7 +73,7 @@ for (ds in seq_along(speciesData)) {
 names(processedData) <- namesProcessedData
 
 # Save for use in model construction
-processedData <- processedData[lapply(processedData,length)>0]
+processedData <- processedData[lapply(processedData,nrow)>0]
 saveRDS(processedData, paste0(folderName, "/speciesDataProcessed.RDS"))
 
 
@@ -140,7 +141,7 @@ if(nrow(processedRedListPresenceData) > 0){
 
 # To add metadata we need to reformat the data as one data frame, as opposed to the list format it is currently in.
 rmarkdown::render("pipeline/integration/utils/metadataProduction.Rmd", output_file = paste0("../../../",folderName, "/speciesMetadata.html"))
-file.copy(paste0(folderName, "/speciesMetadata.html"), "visualisation/hotspotMaps")
+file.copy(paste0(folderName, "/speciesMetadata.html"), "visualisation/hotspotMaps", overwrite = TRUE)
 
 
 ###---------------------###

--- a/pipeline/integration/utils/defineProcessing.R
+++ b/pipeline/integration/utils/defineProcessing.R
@@ -18,7 +18,13 @@ if (dataType == "insectMonitoring") {
   focalEndpoint <- metadata$DWCEndpoint[metadata$name == datasetName]
   newDataset <- processFieldNotes(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon)
   
-# 4. Field note data (with events table)
+# 4. Field note data  - Oslo and Agder
+} else if (dataType == "fieldNotesOslo"){
+  focalEndpoint <- metadata$DWCEndpoint[metadata$name == datasetName]
+  newDataset <- processFieldNotesOslo(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon)
+  
+  
+# 5. Field note data (with events table)
 } else if (dataType == "fieldNotesEvent") {
   focalEndpoint <- metadata$DWCEndpoint[metadata$name == datasetName]
   newDataset <- processFieldNotesEvent(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon)

--- a/pipeline/integration/utils/metadataProduction.Rmd
+++ b/pipeline/integration/utils/metadataProduction.Rmd
@@ -46,7 +46,7 @@ infoNames <- c("Date",
                "Total datasets used", 
                "DOI")
 info <- c(dateAccessed, paste(focalTaxa, collapse = ", "), level, region, totalSpecies,
-          length(unique(processedDataDF$dsName)), attr(downloadKey, "doi"))
+          length(unique(processedDataDF$dsName)), downloadKey$doi)
 basicInfo <- data.frame(Characteristic = infoNames, Value = info)
 knitr::kable(basicInfo)
 ```

--- a/pipeline/models/speciesModelRuns.R
+++ b/pipeline/models/speciesModelRuns.R
@@ -30,7 +30,7 @@ if (!file.exists(modelFolderName)) {
 sapply(list.files("functions", full.names = TRUE), source)
 
 # Import species list
-focalTaxon <- read.csv("data/external/focalTaxa.csv")
+focalTaxon <- read.csv(paste0(folderName, "/focalTaxa.csv"), header = T)
 focalTaxa <- unique(focalTaxon[focalTaxon$include, "taxa"])
 redList <- readRDS(paste0(folderName, "/redList.RDS"))
 
@@ -63,7 +63,7 @@ for (i in 1:length(names(workflowList))) {
   workflow$addMesh(cutoff= myMesh$cutoff, max.edge=myMesh$max.edge, offset= myMesh$offset)
   workflow$specifySpatial(prior.range = c(300000, 0.05),
                           prior.sigma = c(500, 0.2)) #100
-  workflow$workflowOutput('Maps')
+  workflow$workflowOutput('Predictions')
   workflow$modelOptions(INLA = list(control.inla=list(int.strategy = 'eb', cmin = 0),
                                     safe = TRUE))
   


### PR DESCRIPTION
# Why have changes been made?

During a recent run I discovered several issues with our species processing scripts. These need to be more flexible if we have missing columns and such - this is an initial attempt to solve this.

# What changes have been made?

- functions/processFieldNotes.R - when column eventID not present, eventID created from locality and date
- functions/processFieldNotesOslo.R - sseparate script created for Oslo/Agder style datasets
- pipeline/integration/utils/defineProcessing.R - allows for new function
- pipeline/integration/speciesDataProcessing.R - change to remove any datasets with no data

**General changes to all fieldNotes scripts**
- Species outside of relevant taxa are not checked for absences
- coordinateUncertaintyInMetres is filtered much earlier
- individualCount is set to one for all occurrence data, then subsequent NAs produced by creation of absences are set to 0

**Additional bug fixes**
- functions/taxaCheck.R and functions/findGBIFName.R - stupid error whereby GBIF backbone won't find the name if there's no capitalised genus name, so I've capitalised the genus name if need be
- pipeline/integration/speciesDataProcessing.R and pipeline/models/speciesModelRuns.R - focalTaxon import done locally
- pipeline/integration/utils/metadataProduction.Rmd - fixed DOI object