### PR TITLE
make redlist filter optional in modelPreparation

### DIFF
--- a/functions/modelPreparation.R
+++ b/functions/modelPreparation.R
@@ -41,7 +41,10 @@ modelPreparation <- function(focalTaxon, speciesData, redListModelled = NULL, re
     # Define species group to create
     focalGroup <- focalTaxa[i]
     
-    # We need to remove all unnecessary species datasets from the species data
+    # We need to use only species that are 
+    # a) in the right taxa
+    # b) are in our list of red list species to model (this can also be removed if we just want to model all species)
+    # c) have a valid accepted scientific name
     focalSpeciesDataRefined <- lapply(speciesData, FUN = function(x) {
       focalDataset <- x[x$taxa %in% focalGroup & 
                           if(is.null(redListModelled)) {

--- a/functions/modelPreparation.R
+++ b/functions/modelPreparation.R
@@ -5,7 +5,7 @@
 #'
 #' @param focalTaxa A vector of the taxonomic groups we are modelling.
 #' @param speciesData A list of processed datasets to be used in the intSDM models.
-#' @param redListModelled A vector of red listed species found in the datasets with enough occurrences for a decent model.
+#' @param redListModelled A vector of red listed species found in the datasets with enough occurrences for a decent model. If NULL, all species will be modelled.
 #' @param regionGeometry An sf object encompassing our region of study, as produced by defineRegion.
 #' @param modelFolderName The directory where model outputs should be saved.
 #' @param environmentalDataList A list of raster giving relevant environmental variables.

--- a/functions/modelPreparation.R
+++ b/functions/modelPreparation.R
@@ -12,8 +12,11 @@
 #' @param crs The coordinate reference system used in the workflow.
 #' 
 #' @return An R6 environment object with enough information to run an intSDM model.
-
-modelPreparation <- function(focalTaxon, speciesData, redListModelled, regionGeometry, modelFolderName, environmentalDataList = NULL, crs = NULL) {
+#' @importFrom terra nlyr
+#' @importFrom sf st_sf
+#' @importFrom intSDM startWorkflow
+#' 
+modelPreparation <- function(focalTaxon, speciesData, redListModelled = NULL, regionGeometry, modelFolderName, environmentalDataList = NULL, crs = NULL) {
   
   if(is.null(crs)){
     if(!is.null(environmentalDataList)){
@@ -40,7 +43,13 @@ modelPreparation <- function(focalTaxon, speciesData, redListModelled, regionGeo
     
     # We need to remove all unnecessary species datasets from the species data
     focalSpeciesDataRefined <- lapply(speciesData, FUN = function(x) {
-      focalDataset <- x[x$taxa %in% focalGroup & x$acceptedScientificName %in% redListModelled & !is.na(x$acceptedScientificName),]
+      focalDataset <- x[x$taxa %in% focalGroup & 
+                          if(is.null(redListModelled)) {
+                            T
+                          } else {
+                            x$acceptedScientificName %in% redListModelled
+                          } &
+                          !is.na(x$acceptedScientificName),]
       if (nrow(focalDataset) == 0) {
         focalDataset <- NA
       }

--- a/pipeline/models/speciesModelRuns.R
+++ b/pipeline/models/speciesModelRuns.R
@@ -42,8 +42,13 @@ projCRS <- readRDS(paste0(tempFolderName,"/projCRS.RDS"))
 
 # Prepare models
 
-workflowList <- modelPreparation(focalTaxon, speciesData, redList$GBIFName[redList$valid], 
-                                 regionGeometry, modelFolderName, environmentalDataList, projCRS)
+# Prepare models
+workflowList <- modelPreparation(focalTaxon, speciesData, 
+                                 redListModelled = redList$GBIFName[redList$valid], 
+                                 regionGeometry = regionGeometry,
+                                 modelFolderName = modelFolderName, 
+                                 environmentalDataList = environmentalDataList, 
+                                 crs = projCRS)
 focalTaxaRun <- names(workflowList)
 
 ###----------------###


### PR DESCRIPTION
# Why have changes been made?

- currently, modelPreparation requires redListModelled to filter species to model. Update allows for redListModelled to be left as NULL, in which case all SDMs will be fit to all species. 

# What changes have been made?

- functions/modelPreparation.R - make redListModelled argument to be NULL by default, and remove species filter by species when NULL in focalSpeciesDataRefined.
-pipeline/models/speciesModelRuns.R - specify arguments explicitly by name in modelPreparation()