### PR TITLE
debug Filter out relevant GBIF issues

### DIFF
--- a/pipeline/import/utils/formatScheduledDownload.R
+++ b/pipeline/import/utils/formatScheduledDownload.R
@@ -18,7 +18,7 @@ occurrences <- occurrences[,c("acceptedScientificName", "decimalLongitude", "dec
 issuesToFlag <- c("ZERO_COORDINATE|COORDINATE_OUT_OF_RANGE|COORDINATE_INVALID|COORDINATE_PRECISION_INVALID|COORDINATE_UNCERTAINTY_METRES_INVALID")
 occurrences <- occurrences %>%
   filter(datasetKey %in% dataTypes$datasetKey[!is.na(dataTypes$processing)]) %>%
-  filter(grepl(issuesToFlag,issue))
+  filter(!grepl(issuesToFlag,issue))
 
 # Assign a taxon key based on what level of taxonomy the key is valid for
 occurrences$taxonKeyProject <- ifelse(occurrences$kingdomKey %in% focalTaxon$key, occurrences$kingdomKey,

--- a/pipeline/models/utils/modelResultsCompilation.R
+++ b/pipeline/models/utils/modelResultsCompilation.R
@@ -30,13 +30,13 @@ for (i in seq_along(focalTaxaRun)) {
                             pattern = "Predictions.rds", 
                             full.names = T, recursive = T)
   biases <- list.files(groupFolderLocation, 
-                            pattern = "biasPreds.rds", 
-                            full.names = T, recursive = T)
+                       pattern = "biasPreds.rds", 
+                       full.names = T, recursive = T)
   speciesIntensities <- lapply(predictions, readRDS)
   taxaBias <- lapply(biases, readRDS)
   
   # Scale all columns for each species between 0 and 1
-  speciesIntensitiesScaled <- lapply(1:length(speciesIntensities), FUN = function(x) {
+  speciesIntensitiesScaled <- lapply(seq_along(speciesIntensities), FUN = function(x) {
     intensityList <- speciesIntensities[[x]]
     intensityVector <- intensityList$predictions$mean
     intensityScaled <- (intensityVector - min(intensityVector))/(max(intensityVector)-min(intensityVector))
@@ -46,7 +46,7 @@ for (i in seq_along(focalTaxaRun)) {
   })
   
   # Get all biases for datasets
-  taxaBiasesScaled <- lapply(1:length(taxaBias), FUN = function(x) {
+  taxaBiasesScaled <- lapply(seq_along(taxaBias), FUN = function(x) {
     biasList <- taxaBias[[x]]
     biasVector <- biasList$biasFields$sharedBias$mean
     biasScaled <- (biasVector - min(biasVector))/(max(biasVector)-min(biasVector))


### PR DESCRIPTION
# Why have changes been made?
1. previous filtering of GBIF issue flags retained records with issues rather than excluding them. Must use '!' operator in combination with grepl to exclude records with issue. 
2. error when defining taxaBiasesScaled when no taxaBias present, use seq_along() instead of 1:length(taxaBias).

# What changes have been made?
- pipeline/import/utils/formatScheduledDownload.R - added '!' to issue filtering
- modelReslutsCompilation - use seq_along() instead of 1:length(taxaBias).