### PR TITLE
add simpleScientificName to non-RedList species

### DIFF
--- a/pipeline/integration/speciesDataProcessing.R
+++ b/pipeline/integration/speciesDataProcessing.R
@@ -72,7 +72,9 @@ for (ds in seq_along(speciesData)) {
       simpleScientificName = coalesce(
         redList$species[match(acceptedScientificName, redList$GBIFName)],  # Match redList species
         str_extract(acceptedScientificName, "^[A-Za-z]+\\s+[a-z]+")        # Extract binomial name
-      )
+      ),
+      # Replace space with underscore in simpleScientificName
+      simpleScientificName = str_replace(simpleScientificName, " ", "_")
     )
   
   # Add in polyphyletic taxa

--- a/pipeline/integration/speciesDataProcessing.R
+++ b/pipeline/integration/speciesDataProcessing.R
@@ -66,8 +66,14 @@ for (ds in seq_along(speciesData)) {
   newDataset <- NULL
   
   source("pipeline/integration/utils/defineProcessing.R")
-  
-  newDataset$simpleScientificName <- redList$species[match(newDataset$acceptedScientificName, redList$GBIFName)]
+  # add simpleScientificName column
+  newDataset <- newDataset %>%
+    mutate(
+      simpleScientificName = coalesce(
+        redList$species[match(acceptedScientificName, redList$GBIFName)],  # Match redList species
+        str_extract(acceptedScientificName, "^[A-Za-z]+\\s+[a-z]+")        # Extract binomial name
+      )
+    )
   
   # Add in polyphyletic taxa
   newDataset$taxa <- ifelse(newDataset$acceptedScientificName %in% polyphyleticSpecies$acceptedScientificName, 


### PR DESCRIPTION
# Why have changes been made?

- when modelling any species that aren't in redList data.frame, definition of simpleScientificName in newDataset is NA, leading to errors in sdmWorkflow(workflow, predictionDim = c(240,320)). 

# What changes have been made?

- pipeline/integration/speciesDataProcessing.R 
 first, match species name from redList$species, else, extract binomial name from accetpedSceintificName
