### PR TITLE
Bug fix -  ImportRedlist.R

### DIFF
--- a/data/run_2024-01-08/focalTaxa.csv
+++ b/data/run_2024-01-08/focalTaxa.csv
@@ -1,0 +1,9 @@
+"taxa","key","level","scientificName","include","functionalGroup"
+"amphibiansReptiles",11592253,"class","Squamata",TRUE,NA
+"amphibiansReptiles",131,"class","Amphibia",TRUE,NA
+"spiders",367,"class","Arachnida",TRUE,NA
+"bugs",809,"order","Hemiptera",TRUE,NA
+"caddislflies",1003,"order","Tricoptera",TRUE,NA
+"dragonflies",789,"order","Odonata",TRUE,NA
+"fungi",5,"kingdom","Fungi",TRUE,NA
+"lichens",NA,"polyphyla","Lichens",TRUE,NA

--- a/data/run_2024-01-09/focalTaxa.csv
+++ b/data/run_2024-01-09/focalTaxa.csv
@@ -1,0 +1,9 @@
+"taxa","key","level","scientificName","include","functionalGroup"
+"amphibiansReptiles",11592253,"class","Squamata",TRUE,NA
+"amphibiansReptiles",131,"class","Amphibia",TRUE,NA
+"spiders",367,"class","Arachnida",TRUE,NA
+"bugs",809,"order","Hemiptera",TRUE,NA
+"caddislflies",1003,"order","Tricoptera",TRUE,NA
+"dragonflies",789,"order","Odonata",TRUE,NA
+"fungi",5,"kingdom","Fungi",TRUE,NA
+"lichens",NA,"polyphyla","Lichens",TRUE,NA

--- a/functions/importRedList.R
+++ b/functions/importRedList.R
@@ -11,7 +11,9 @@
 importRedList <- function(categories) {
   redListCategories <- lapply(categories, FUN = function(x) {
     apiQuery <- httr::GET(paste0("https://artsdatabanken.no/api/Resource/?Take=999999&Type=taxon&Tags=Kategori/", x))
-    data <- jsonlite::fromJSON(rawToChar(apiQuery$content))
+    charChange <- rawToChar(apiQuery$content)
+    Encoding(charChange) <- "UTF-8" #The encoding for fromJSON should be UTF-8
+    data <- jsonlite::fromJSON(charChange, flatten = TRUE)
     cbind(data$AcceptedNameUsage$ScientificName, data$Kategori)}
   )
   

--- a/masterScript.R
+++ b/masterScript.R
@@ -20,7 +20,7 @@ sapply(list.files("functions", full.names = TRUE, recursive = TRUE), source)
 # Let's get started! The first script to run is the speciesImport.R script, which requires that you
 # define a spatial level on which to run the pipeline, as well as a region within Norway. The options are
 # "country", "county", "municipality", or "points", which is a box created by latitudinal and longitudinal 
-# points (example given below). The default options are set for the county of Trøndelag. Codes for
+# points (example given below). The default options are set for the county of TrC8ndelag. Codes for
 # different municipalities and couunites in Norway can be found at this link:
 # https://kartverket.no/til-lands/kommunereform/tekniske-endringer-ved-sammenslaing-og-grensejustering/komendr2020
 
@@ -38,7 +38,7 @@ res <- 1000 # resolution in units of CRS (eg m in UTM, or degrees in lat/long)
 # FALSE here.
 
 scheduledDownload <- TRUE
-waitForGbif <- TRUE
+waitForGbif <- FALSE
 source("pipeline/import/taxaImport.R")
 
 # Next we run the environmental import script, which brings in a set of rasters that apply to the region


### PR DESCRIPTION
# Why have changes been made?

The importRedList function returned errors, due to encoding problems. This has been fixed.

# What changes have been made?

-functions/importRedList.R We (I and @samaperrin ) have made the default encoder to be "UTF-8".

