### PR TITLE
Tidy env check down imp water dist

### DIFF
--- a/data/external/focalCovariates.csv
+++ b/data/external/focalCovariates.csv
@@ -32,3 +32,4 @@ building_density,FALSE,FALSE,ssb
 net_primary_productivity,TRUE,TRUE,modis
 land_cover_corine,TRUE,TRUE,corine
 ndvi_peak,TRUE,TRUE,modis
+distance_water,TRUE,TRUE,corine

--- a/functions/checkAndImportRast.R
+++ b/functions/checkAndImportRast.R
@@ -1,0 +1,20 @@
+# Define the path for data source
+checkAndImportRast <- function(parameter, regionGeometry, dataPath, fileType = "tiff") {
+  # Initialize the raster found flag
+  raster <- NULL
+  
+  # List all files in the directory that match the parameter
+  filePattern <- paste0(parameter, sprintf( "_.*\\.%s$", fileType))
+  fileList <- list.files(path = dataPath, pattern = filePattern, full.names = TRUE)
+  
+  # Check each file
+  for (file in fileList) {
+    rastObj <- terra::rast(file)
+    if (isSubset(regionGeometry, rastObj)) {
+      raster <- rastObj
+      cat(sprintf("Raster for '%s' encompassing region found and imported successfully!\n", parameter))
+      break
+    } 
+  } 
+  return(raster)
+}

--- a/functions/checkAndImportRast.R
+++ b/functions/checkAndImportRast.R
@@ -1,10 +1,10 @@
 # Define the path for data source
-checkAndImportRast <- function(parameter, regionGeometry, dataPath, fileType = "tiff") {
+checkAndImportRast <- function(parameter, regionGeometry, dataPath, fileType = "tiff", quiet = FALSE) {
   # Initialize the raster found flag
   raster <- NULL
   
   # List all files in the directory that match the parameter
-  filePattern <- paste0(parameter, sprintf( "_.*\\.%s$", fileType))
+  filePattern <- paste0(parameter, sprintf("_.*\\.%s$", fileType))
   fileList <- list.files(path = dataPath, pattern = filePattern, full.names = TRUE)
   
   # Check each file
@@ -12,9 +12,12 @@ checkAndImportRast <- function(parameter, regionGeometry, dataPath, fileType = "
     rastObj <- terra::rast(file)
     if (isSubset(regionGeometry, rastObj)) {
       raster <- rastObj
-      cat(sprintf("Raster for '%s' encompassing region found and imported successfully!\n", parameter))
+      if (!quiet) {
+        message(sprintf("Raster for '%s' encompassing region found and imported successfully!\n", parameter))
+      }
       break
-    } 
-  } 
+    }
+  }
+  
   return(raster)
 }

--- a/functions/generateRastFileName.R
+++ b/functions/generateRastFileName.R
@@ -1,0 +1,20 @@
+generateRastFileName <- function(raster, parameter, dataPath, fileType = "tiff") {
+  # Extract CRS information
+  crsInfo <- terra::crs(raster, describe = TRUE)
+  
+  # Construct info string based on CRS and extent
+  if (!is.na(crsInfo$authority)) {
+    extentObj <- terra::ext(raster)
+    info <- sprintf("%s%s_X%s_%s_Y%s_%s",
+                    crsInfo$authority, crsInfo$code, 
+                    extentObj[1], extentObj[2], extentObj[3], extentObj[4])
+  } else {
+    # Use digest for non-descriptive CRS
+    info <- digest::digest(list(terra::crs(raster), terra::ext(raster)))
+  }
+  
+  # Construct the file path with raster information
+  filePath <- sprintf("%s/%s_%s.%s", dataPath, parameter, info, fileType)
+  return(filePath)
+}
+

--- a/pipeline/import/environmentalImport.R
+++ b/pipeline/import/environmentalImport.R
@@ -113,23 +113,6 @@ for (parameter in seq_along(selectedParameters)) {
     if (!raster_found) {
       # download file
       source(paste0("pipeline/import/utils/defineEnvSource.R"))
-      # get info to save
-      info <- crs(rasterisedVersion, describe = T)
-      if(!is.na(info$authority)){
-        ext <- ext(rasterisedVersion)
-        info <- sprintf("%s%s_X%s_%s_Y%s_%s",
-                        info$authority, info$code, 
-                        ext[1], ext[2], ext[3], ext[4])
-      } else {
-        info <- digest(list(crs(rasterisedVersion), ext(rasterisedVersion)))
-      }
-      #  Construct the filename and save with raster information
-      file_path <- sprintf("data/temp/%s/%s_%s.tiff",
-                           dataSource,focalParameter, info)
-      x <- rasterisedVersion
-      if(!file.exists(file_path)){
-        writeRaster(x, filename = file_path, overwrite = TRUE)
-      }
     }
   } else {
     rasterisedVersion <- rast(paste0("data/external/environmentalCovariates/",focalParameter, ".tiff"))

--- a/pipeline/import/environmentalImport.R
+++ b/pipeline/import/environmentalImport.R
@@ -79,38 +79,25 @@ baseRaster <- terra::rast(extent = ext(regionGeometryBuffer), res = res, crs = p
 # download environmental data
 parameterList <- list()
 
-for (parameter in seq_along(selectedParameters)) {
+for(parameter in seq_along(selectedParameters)) {
+  rasterisedVersion <- NULL
   focalParameter <- selectedParameters[parameter]
   
   ### 1. Check if the data needs to be downloaded externally.
   external <- parameters$external[parameters$parameters == focalParameter]
   
-  if (external) {
+  if(external) {
     dataSource <- parameters$dataSource[parameters$parameters == focalParameter]
     
     ### 2. Check whether we have previously downloaded a version of the external data that encompasses the area we need.
-    raster_found <- FALSE
-    if(dir.exists(paste0("data/temp/", dataSource))){
-      ## List all files in the directory that match the parameter
-      file_list <- list.files(path = paste0("data/temp/", dataSource), 
-                              pattern = paste0(focalParameter, "_.*\\.tiff$"), 
-                              full.names = TRUE)
-      # Check files
-      for (file in file_list) {
-        rast <- rast(file)
-        if (isSubset(regionGeometryBuffer, rast)) {
-          rasterisedVersion <- rast
-          raster_found <- TRUE
-          cat(sprintf("Raster for '%s' encompassing region found and imported successfully!\n",
-                      focalParameter))
-          break
-        } 
-      }   
+    dataPath <- paste0("data/temp/", dataSource)
+    if(dir.exists(dataPath)){
+      rasterisedVersion <- checkAndImportRast(focalParameter, regionGeometryBuffer, dataPath)
       # 3. Create new temp folder to download necessary external data.
     } else {
-      dir.create(paste0("data/temp/", dataSource))
+      dir.create(dataPath)
     }
-    if (!raster_found) {
+    if(is.null(rasterisedVersion)) {
       # download file
       source(paste0("pipeline/import/utils/defineEnvSource.R"))
     }

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -61,6 +61,7 @@ if (dataSource == "geonorge") {
 } else if (dataSource == "corine") {
   # check if encompassing corine alreadydownloaded
   rasterisedVersion <- checkAndImportRast("land_cover_corine", regionGeometryBuffer, dataPath, quiet = TRUE)
+  # rasterisedVersion <- terra::crop(rasterisedVersion, terra::project(regionGeometryBuffer, rasterisedVersion))
   # download and save if missing
   if(is.null(rasterisedVersion)){
     # download
@@ -71,16 +72,13 @@ if (dataSource == "geonorge") {
   }
   # calculate distance to water (if necessary)
   if (focalParameter == 'distance_water') {
-    # Extract the levels data frame
-    levels <- levels(rasterisedVersion)[[1]]
     # Find the numeric value corresponding to "Water bodies"
-    water_val <- levels[levels[,2] == "Water bodies", 1]
     message("Identifying water cells in corine data.")
-    water <- rasterisedVersion == water_val
-    message("Nullifying non-water cells in corine data.")
-    water[!isTRUE(water)] <- NA # Assign NA to cells that are not water bodies
+    rasterisedVersion[!(rasterisedVersion == "Water bodies")] <- NA 
     message("Calculating distance to water.")
-    rasterisedVersion <- distance(water)
+    rasterisedVersion <- terra::distance(rasterisedVersion) 
+    # round to nearest 10m to reduce file size
+    rasterisedVersion <- round(rasterisedVersion/10)*10
   }
 }
 

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -60,7 +60,7 @@ if (dataSource == "geonorge") {
   rasterisedVersion <- get_modis(regionGeometryBuffer, projCRS, focalParameter)
 } else if (dataSource == "corine") {
   # check if encompassing corine alreadydownloaded
-  rasterisedVersion <- checkAndImportRast("land_cover_corine", regionGeometryBuffer, dataPath)
+  rasterisedVersion <- checkAndImportRast("land_cover_corine", regionGeometryBuffer, dataPath, quiet = TRUE)
   # download and save if missing
   if(is.null(rasterisedVersion)){
     # download

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -56,7 +56,7 @@ if (dataSource == "geonorge") {
     
 ### 4. MODIS ####    
 } else if (dataSource == "modis") {
-  rasterisedVersion <- get_modis(regionGeometry, projCRS, focalParameter)
+  rasterisedVersion <- get_modis(regionGeometryBuffer, projCRS, focalParameter)
 } else if (dataSource == "corine") {
   rasterisedVersion <- get_corine()
 }

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -75,8 +75,11 @@ if (dataSource == "geonorge") {
     levels <- levels(rasterisedVersion)[[1]]
     # Find the numeric value corresponding to "Water bodies"
     water_val <- levels[levels[,2] == "Water bodies", 1]
+    message("Identifying water cells in corine data.")
     water <- rasterisedVersion == water_val
+    message("Nullifying non-water cells in corine data.")
     water[!isTRUE(water)] <- NA # Assign NA to cells that are not water bodies
+    message("Calculating distance to water.")
     rasterisedVersion <- distance(water)
   }
 }

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -8,14 +8,15 @@ if(inherits(regionGeometryBuffer, c("sf", "sfc"))){
 }
 ### 1. geonorge ####
 if (dataSource == "geonorge") { 
-  if (file.exists("data/temp/geonorge/elevationRaster.tiff")) { 
-    elevation <- rast("data/temp/geonorge/elevationRaster.tiff")
-  } else {
-    if (!dir.exists("data/temp/geonorge")) {
-      dir.create("data/temp/geonorge", recursive = TRUE)
-    }
+  # check if encompassing corine alreadydownloaded
+  elevation <- checkAndImportRast("elevation", regionGeometryBuffer, dataPath)
+  # download and save if missing
+  if(is.null(elevation)){
+    # download
     elevation <- get_geonorge(targetDir = tempFolderName)
-    writeRaster(elevation, "data/temp/geonorge/elevationRaster.tiff", overwrite=TRUE)
+    # save
+    file_path <- generateRastFileName(elevation, dataSource, "elevation", dataPath)
+    writeRaster(elevation, filename = file_path, overwrite = TRUE)
   }
   
   # Now get the raster you're actually looking for

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -64,3 +64,6 @@ if (dataSource == "geonorge") {
 ### merge with requested download area to make missing data explicit
 rasterisedVersion <- extend(rasterisedVersion, terra::project(regionGeometryBuffer, rasterisedVersion), snap = "out")
 
+### generate descriptive file name and save
+file_path <- generateRastFileName(rasterisedVersion, focalParameter, dataPath)
+writeRaster(rasterisedVersion, filename = file_path, overwrite = TRUE)

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -74,7 +74,7 @@ if (dataSource == "geonorge") {
     # Extract the levels data frame
     levels <- levels(rasterisedVersion)[[1]]
     # Find the numeric value corresponding to "Water bodies"
-    water_val <- levels[levels$LABEL3 == "Water bodies", 1]
+    water_val <- levels[levels[,2] == "Water bodies", 1]
     water <- rasterisedVersion == water_val
     water[!isTRUE(water)] <- NA # Assign NA to cells that are not water bodies
     rasterisedVersion <- distance(water)


### PR DESCRIPTION
# Why have changes been made?
- environmentalImport was hard to read with checking, importing, downloading, and saving parameter rasters; these have now been replaced with designated functions and have been moved into defineEnvSource.R. 
- defineEnvSource did not check whether existing elevation raster encompassed the study region before downloading.
- added code in defineEnvSource to calculate distance to water from corine data
- get_modis in defineEnvSource used regionGeometry instead of regionGeometryBuffer.

# What changes have been made?
- data/external/focalCovariates.csv - distance_water: derived from corine
- functions/checkAndImportRast.R - explore given dataPath for raster of a given parameter that encompasses a regionGeometry of interest
- functions/generateRastFileName.R - generate a descriptive file path/name for a raster based on its spatial extent, resolution, and parameter name.
- pipeline/import/environmentalImport.R - use checkAndImportRast to search/import rasters, and move saving into defineEnvSource
- pipeline/import/utils/defineEnvSource.R - save raster at the end, use regionGeometryBuffer in get_modis, check if elevation covers region before calculating slope/aspect, add 'distance_water' calculation from corine data