### PR TITLE
Removed 'flatten' bug from importRedList

### DIFF
--- a/functions/importRedList.R
+++ b/functions/importRedList.R
@@ -13,7 +13,7 @@ importRedList <- function(categories) {
     apiQuery <- httr::GET(paste0("https://artsdatabanken.no/api/Resource/?Take=999999&Type=taxon&Tags=Kategori/", x))
     charChange <- rawToChar(apiQuery$content)
     Encoding(charChange) <- "UTF-8" #The encoding for fromJSON should be UTF-8
-    data <- jsonlite::fromJSON(charChange, flatten = TRUE)
+    data <- jsonlite::fromJSON(charChange)
     cbind(data$AcceptedNameUsage$ScientificName, data$Kategori)}
   )
   


### PR DESCRIPTION
# Why have changes been made?

In a recent push we introduced a 'flatten' argument to the JSON reading function which I didn't check properly and left us with a bug. Have fixed this now.

# What changes have been made?

- functions/importRedList.R - FLATTEN argument was removed