### PR TITLE
Addition of CHELSA snow cover data

### DIFF
--- a/data/external/focalCovariates.csv
+++ b/data/external/focalCovariates.csv
@@ -33,3 +33,4 @@ net_primary_productivity,TRUE,TRUE,modis
 land_cover_corine,TRUE,TRUE,corine
 ndvi_peak,TRUE,TRUE,modis
 distance_water,TRUE,TRUE,corine
+snow_cover,TRUE,TRUE,chelsa

--- a/functions/get_chelsa.R
+++ b/functions/get_chelsa.R
@@ -1,0 +1,30 @@
+
+#' @title \emph{get_chelsa}: This function downloads and merges different chelsa data based on the link provided
+
+#' @description Chelsa has a range of climate data - this function downloads them based on the parameter chosen. All dataset links can be found here https://envicloud.wsl.ch/#/?prefix=chelsa%2Fchelsa_V2%2FGLOBAL%2F.
+#'
+#' @param parameter The chosen parameter. The function has the relevant link to the dataset built in.
+#'
+#' 
+#' @return A SpatRaster of Chelsa layers.
+
+
+get_chelsa <- function(parameter) {
+
+  # Check whether chelsa directory exists
+  if (!dir.exists("data/temp/chelsa/")) {
+    dir.create("data/temp/chelsa/")
+  }
+  
+  if (parameter == "snow_cover") {
+    focalURL <- "https://os.zhdk.cloud.switch.ch/envicloud/chelsa/chelsa_V2/GLOBAL/climatologies/1981-2010/bio/CHELSA_scd_1981-2010_V.2.1.tif"
+  }
+  fileName <- paste0("data/temp/chelsa/",parameter,".tif")
+  
+  download.file(focalURL, destfile= fileName)
+  
+  rasterised_version <- terra::rast(fileName)
+  return(rasterised_version)
+}
+
+

--- a/functions/get_chelsa.R
+++ b/functions/get_chelsa.R
@@ -10,21 +10,12 @@
 
 
 get_chelsa <- function(parameter) {
-
-  # Check whether chelsa directory exists
-  if (!dir.exists("data/temp/chelsa/")) {
-    dir.create("data/temp/chelsa/")
-  }
-  
   if (parameter == "snow_cover") {
     focalURL <- "https://os.zhdk.cloud.switch.ch/envicloud/chelsa/chelsa_V2/GLOBAL/climatologies/1981-2010/bio/CHELSA_scd_1981-2010_V.2.1.tif"
   }
-  fileName <- paste0("data/temp/chelsa/",parameter,".tif")
-  
-  download.file(focalURL, destfile= fileName)
-  
-  rasterised_version <- terra::rast(fileName)
-  return(rasterised_version)
+  message(sprintf("Downloading, %s raster from chelsa.", parameter))
+  raster <- terra::rast(focalURL)
+  return(raster)
 }
 
 

--- a/functions/isSubset.R
+++ b/functions/isSubset.R
@@ -7,7 +7,8 @@
 #' @importFrom terra ext
 #' @importFrom sf st_bbox
 isSubset <- function(x, y, dfMaxLength){ 
-  
+  suppressMessages(sf_use_s2(FALSE))  # conduct all calculation assuming planar geometries 
+  library(tidyterra)
   # vectorise
   x <- vectorize(x)
   y <- vectorize(y)
@@ -29,21 +30,23 @@ isSubset <- function(x, y, dfMaxLength){
   # calculate area of x and check overlap
   area_x <- sum(st_area(x))
   # due to rounding, allow for difference of 0.01 %
-  return(
-    as.numeric(abs((sum(st_area(x)) - sum(st_area(st_intersection(x, y))))/sum(st_area(x)))) < 1e-4
-  )
+  suppressMessages(subset <- as.numeric(abs((sum(st_area(x)) - sum(st_area(st_intersection(x, y))))/sum(st_area(x)))) < 1e-4)
+  suppressMessages(sf_use_s2(TRUE))
+  return(subset)
 }
 
 # Function to get extent for both terra and sf objects
 vectorize <- function(obj, dfMaxLength) {
   if (inherits(obj, c("sf", "sfc"))) {
-    return(obj)
+    break
   } else if (inherits(obj, "SpatVector")) {
-    return(st_as_sf(obj))
+    obj <- st_as_sf(obj)
   } else if (inherits(obj, "SpatRaster")) {
-    return(st_as_sf(as.polygons(obj, extent = T)))
+    obj <- st_as_sf(as.polygons(obj, extent = T))
   } else {
     stop("Invalid input: x and y should be either SpatRaster, SpatVector, or sf objects.")
   }
+  return(obj)
 }
+
 

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -58,6 +58,8 @@ if (dataSource == "geonorge") {
 ### 4. MODIS ####    
 } else if (dataSource == "modis") {
   rasterisedVersion <- get_modis(regionGeometryBuffer, projCRS, focalParameter)
+  
+### 5. CORINE ###  
 } else if (dataSource == "corine") {
   # check if encompassing corine alreadydownloaded
   rasterisedVersion <- checkAndImportRast("land_cover_corine", regionGeometryBuffer, dataPath, quiet = TRUE)
@@ -80,6 +82,10 @@ if (dataSource == "geonorge") {
     # round to nearest 10m to reduce file size
     rasterisedVersion <- round(rasterisedVersion/10)*10
   }
+  
+### 6. Chelsa ###  
+} else if (dataSource == "chelsa") {
+  rasterisedVersion <- get_chelsa(focalParameter)
 }
 
 ### merge with requested download area to make missing data explicit


### PR DESCRIPTION
# Why have changes been made?

We have managed to find snow cover data from CHELSA at the link below, and need to integrate it.

https://envicloud.wsl.ch/#/?prefix=chelsa%2Fchelsa_V2%2FGLOBAL%2F

# What changes have been made?

- data/external/focalCovariates.csv - snow_cover data added, with Chelsa as the source
- functions/get_chelsa.R - Basic function for importing Chelsa data
- pipeline/import/utils/defineEnvSource.R - Chelsa added as source for env import
