### PR TITLE
Debug of errant characters in simpleScientificName and lack of relevant data in event data processing

### DIFF
--- a/functions/processFieldNotesOslo.R
+++ b/functions/processFieldNotesOslo.R
@@ -52,6 +52,12 @@ processFieldNotesOslo <- function(focalEndpoint, tempFolderName, datasetName, re
   eventLocationsSF <- st_intersection(eventLocationsSF, regionGeometry) %>%
     filter(coordinateUncertaintyInMeters <= 100)
   
+  # At this point we may find that there are no relevant points from this dataset available - 
+  # in this case we want to finish the function early
+  if (nrow(eventLocationsSF) == 0) {
+    return(NULL)
+  }
+  
   # Get a dates table to match years to events
   eventDates <- occurrence %>%
     dplyr::select(year, eventID) %>%

--- a/pipeline/integration/speciesDataProcessing.R
+++ b/pipeline/integration/speciesDataProcessing.R
@@ -108,7 +108,8 @@ processedDataCompiled <- do.call(rbind, lapply(1:length(processedData), FUN = fu
   if (datasetType == "PO") {
     dataset$individualCount <- 1
   }
-  datasetShort <- dataset[, c("acceptedScientificName", "individualCount", "geometry", "taxa", "year", "dataType", "taxonKeyProject")]
+  datasetShort <- dataset[, c("acceptedScientificName", "individualCount", "geometry", "taxa", "year", "dataType", 
+                              "taxonKeyProject", "simpleScientificName")]
   datasetShort$dsName <- datasetName
   datasetShort
 }))

--- a/pipeline/integration/speciesDataProcessing.R
+++ b/pipeline/integration/speciesDataProcessing.R
@@ -66,6 +66,8 @@ for (ds in seq_along(speciesData)) {
   newDataset <- NULL
   
   source("pipeline/integration/utils/defineProcessing.R")
+  if (is.null(newDataset)) {break}
+  
   # add simpleScientificName column
   newDataset <- newDataset %>%
     mutate(
@@ -74,7 +76,7 @@ for (ds in seq_along(speciesData)) {
         str_extract(acceptedScientificName, "^[A-Za-z]+\\s+[a-z]+")        # Extract binomial name
       ),
       # Replace space with underscore in simpleScientificName
-      simpleScientificName = str_replace(simpleScientificName, " ", "_")
+      simpleScientificName = gsub("×","", gsub(" ", "_", simpleScientificName))
     )
   
   # Add in polyphyletic taxa


### PR DESCRIPTION
# Why have changes been made?

We had two bugs to solve. One is [detailed here](https://github.com/gjearevoll/BioDivMapping/issues/99). The other was an error produced by a lack of relevant data within the region surveyed in the data processing functions - this was leading to errors. 

# What changes have been made?

- pipeline/integration/speciesDataProcessing.R - the str_extract function was replaced with two instances of gsub(). An additional lien was also used to skip to the end of the processing loop if the processing function returned a NULL value. simpleScientificName is also now retained in our compiled species dataset. 
- functions/processFieldNotes.R and all other processFieldNotes scripts - A null value is returned for the dataset if there are no occurrences with a coordinate uncertainty of less that 100 metres inside the relevant region.

Additionally [this commit](https://github.com/gjearevoll/BioDivMapping/commit/dc5f65ce29269b60c1a8d02200988b44387d6708) was accidentally made directly to the main branch 
