### PR TITLE
Forest line attempt

### DIFF
--- a/data/external/focalCovariates.csv
+++ b/data/external/focalCovariates.csv
@@ -34,3 +34,4 @@ land_cover_corine,TRUE,TRUE,corine
 ndvi_peak,TRUE,TRUE,modis
 distance_water,TRUE,TRUE,corine
 snow_cover,TRUE,TRUE,chelsa
+forest_line,TRUE,TRUE,nibio

--- a/functions/get_nibio.R
+++ b/functions/get_nibio.R
@@ -1,0 +1,31 @@
+
+#' @title \emph{get_nibio}: This function downloads geographical data directly from Geonorge
+
+#' @description This function checks whether or not you have the correct data stored locally for the forest line and elevation in Norway
+#'
+#' @return An aggregated raster containing elevation data for Norway.
+#'
+#' @import terra
+#' 
+
+# Check out the full list of data repositories here: https://nedlasting.geonorge.no/geonorge/
+# See available data sources: https://nedlasting.geonorge.no/geonorge/Basisdata/
+
+get_nibio <- function(regionGeometryBuffer) {
+  if (!file.exists("data/temp/nibio/fl_800_2017_e")) {
+    cat("Correct file does not exist. If you do not have access to the forest line raster, contact sam.perrin@ntnu.no.")
+    return(NULL)
+  }
+  forestLine <- terra::rast("data/temp/nibio/fl_800_2017_e")
+  
+  # Get elevation raster
+  elevation <- checkAndImportRast("elevation", regionGeometryBuffer, "data/temp/geonorge")
+  
+  # Project forest line onto elevation
+  reprojForestLine <- terra::project(forestLine, elevation)
+  
+  # Calculate distance to forest line
+  distForestLine <- elevation - reprojForestLine  
+  return(distForestLine)
+  
+}

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -86,6 +86,10 @@ if (dataSource == "geonorge") {
 ### 6. Chelsa ###  
 } else if (dataSource == "chelsa") {
   rasterisedVersion <- get_chelsa(focalParameter)
+  
+### 7. NIBIO ###
+} else if (dataSource == "nibio") {
+  rasterisedVersion <- get_nibio()
 }
 
 ### merge with requested download area to make missing data explicit


### PR DESCRIPTION
# Why have changes been made?

We have new data from Anders Bryn at NIBIO which includes forest line data. HOWEVER Anders does not want to original raster data made publicly available. If you want the original data, please contact either Anders directly or myself (Sam). The rasters are used to calculate altitudinal distance from forest line.

# What changes have been made?

- data/external/focalCovariates.csv - new row for NIBIO entrance
- functions/get_nibio.R - New function which imports locally stored forest line data and calculates distance to forest line
- pipeline/import/utils/defineEnvSource.R - option for NIBIO data added

# Extra notes
Our actual metric for distance to forest line may be slightly adjusted i the future - for now simple elevation minus forest line will do.