### PR TITLE
Addition of distance to water/roads with geonorge as a source

### DIFF
--- a/data/external/focalCovariates.csv
+++ b/data/external/focalCovariates.csv
@@ -32,5 +32,6 @@ building_density,FALSE,FALSE,ssb
 net_primary_productivity,TRUE,TRUE,modis
 land_cover_corine,TRUE,TRUE,corine
 ndvi_peak,TRUE,TRUE,modis
-distance_water,TRUE,TRUE,corine
+distance_water,TRUE,TRUE,geonorge
 snow_cover,TRUE,TRUE,chelsa
+distance_roads,TRUE,TRUE,geonorge


### PR DESCRIPTION
# Why have changes been made?

We have more accurate, vectorised data regarding lake and water positions and road data from geonorge, which should be used to calculate distance to roads and distance to water across Norway.

# What changes have been made?

- data/external/focalCovariates.csv - distance to roads added, distance to water now uses geonorge instead of corine
- functions/get_geonorge.R - New section added divided by format output (TIFF vs. GDB). Section for GDB output (water and roads) downloads vector data.
- pipeline/import/utils/defineEnvSource.R - Second section forms a base raster for a more buffered section (to account for roads and water bodies across the region's borders) on which to calculate distance to points of interest

## Notes

- At some point we'll need to add code which includes border data (water/road in Sweden/Finland for areas close to the border)