### PR TITLE
Faster taxa check

### DIFF
--- a/functions/getGbifBackbone.R
+++ b/functions/getGbifBackbone.R
@@ -1,0 +1,31 @@
+#' @title \emph{getGbifBackbone}: get gbif backbone for specifid species names \
+#' 
+#' @description This function looks up taxa name names in GBIF and obtains the backbone.
+#'
+#' @param scientificNames A vector of species names which must be found in GBIFs list of accepted scientific name (use findGBIFName to check this)
+#' 
+#' @return The corresponding dataframe of the taxanomic backbone
+#'
+
+getGbifBackbone <- function(scientificNames){
+  # first character to lower-case
+  scientificNames <- stringr::str_to_sentence(scientificNames)
+  
+  # match names with gbif
+  speciesNameTable <- as.data.frame(rgbif::name_backbone_checklist(ScientificNames))
+  
+  # warning message for missing match/species
+  missingMatch <- ScientificNames[speciesNameTable$matchType == "NONE"]
+  missingSpecies <- ScientificNames[is.na(speciesNameTable$scientificName)]
+  if(length(missingMatch) > 0){
+    warning(sprintf("No valid match was found for the following species (suggest manual check): %s.", 
+                    paste0(missingMatch, collapse = ", ")))
+  }
+  if(length(missingSpecies) > 0){
+    warning(sprintf("No valid species name was found for the following species (suggest manual check): %s.", 
+                    paste0(missingSpecies, collapse = ", ")))
+  }
+  
+  # return
+  return(speciesNameTable)
+}

--- a/functions/getGbifBackbone.R
+++ b/functions/getGbifBackbone.R
@@ -9,7 +9,7 @@
 
 getGbifBackbone <- function(scientificNames){
   # first character to lower-case
-  scientificNames <- stringr::str_to_sentence(scientificNames)
+  ScientificNames <- stringr::str_to_sentence(scientificNames)
   
   # match names with gbif
   speciesNameTable <- as.data.frame(rgbif::name_backbone_checklist(ScientificNames))

--- a/functions/matchBackboneKeys.R
+++ b/functions/matchBackboneKeys.R
@@ -1,0 +1,23 @@
+#' @title \emph{matchBackboneKeys}: Check which of our taxa this species belongs to
+#' 
+#' @description This function looks up species' accepted scientific names in GBIF and checks whether they belong to any of the taxonomic groups.
+#'
+#' @param speciesBackbones A data.frame of species backbones as returned by 'getGbifBackbone'
+#' @param taxaKeys A vector of taxonomic keys for the taxa we're importing.
+#' 
+#' @return The corresponding taxonomic key. If none - we get an NA.
+#'
+#'
+
+matchBackboneKeys <- function(speciesBackbones, taxaKeys){
+  # filter taxa key  
+  out <- ifelse(speciesBackbones$kingdomKey %in% taxaKeys, speciesBackbones$kingdomKey,
+                ifelse(speciesBackbones$phylumKey %in% taxaKeys, speciesBackbones$phylumKey,
+                       ifelse(speciesBackbones$classKey %in% taxaKeys, speciesBackbones$classKey,
+                              ifelse(speciesBackbones$orderKey %in% taxaKeys, speciesBackbones$orderKey,
+                                     ifelse(speciesBackbones$familyKey %in% taxaKeys, speciesBackbones$familyKey,
+                                            ifelse(speciesBackbones$genusKey %in% taxaKeys, speciesBackbones$genusKey,
+                                                   ifelse(speciesBackbones$speciesKey %in% taxaKeys, speciesBackbones$speciesKey, NA)))))))
+  # return
+  return(out)
+}

--- a/pipeline/import/taxaImport.R
+++ b/pipeline/import/taxaImport.R
@@ -68,8 +68,9 @@ if (file.exists(paste0(tempFolderName, "/redList.RDS"))) {
   
   # Match to accepted names
   speciesBackbones <- getGbifBackbone(redList$species)
+  redList$taxaKey <- matchBackboneKeys(speciesBackbones, focalTaxon$key)
   redList$taxa <- focalTaxon$taxa[match(redList$taxaKey, focalTaxon$key[!is.na(focalTaxon$key)])]
-  redList$GBIFName <- sapply(redList$species, FUN = findGBIFName)
+  redList$GBIFName <- speciesBackbones$scientificName
   
   # Add polyphyletic taxa
   polyphylaTaxaVector <-  polyphyleticSpecies$taxa[match(redList$GBIFName, polyphyleticSpecies$acceptedScientificName)]

--- a/pipeline/import/taxaImport.R
+++ b/pipeline/import/taxaImport.R
@@ -67,7 +67,7 @@ if (file.exists(paste0(tempFolderName, "/redList.RDS"))) {
   redList <- importRedList(redListCategories)
   
   # Match to accepted names
-  redList$taxaKey <- sapply(redList$species, FUN = function(x) {taxaCheck(x, focalTaxon$key)})
+  speciesBackbones <- getGbifBackbone(redList$species)
   redList$taxa <- focalTaxon$taxa[match(redList$taxaKey, focalTaxon$key[!is.na(focalTaxon$key)])]
   redList$GBIFName <- sapply(redList$species, FUN = findGBIFName)
   


### PR DESCRIPTION
# Why have changes been made?
Getting taxa keys and scientifc name for redlist species was very slow. First, use rgbif::name_backbone_checklist (vectorised version of name_backbone). second, call it once to get the backbone for all species and use it to get taxa key and name directly (instead of two functions that obtain the backbone separately). 

# What changes have been made?

- functions/getGbifBackbone.R - 
function obtains gbif backbone using rgbif::name_backbone_checklist (accepts a vector of scientific names) 
- functions/matchBackboneKeys.R - 
replacement of taxaChecklist to extract taxa keys from gbif backbone
- pipeline/import/taxaImport.R - utilise the getGbifBackbone & matchBackboneKeys functions and extract scientific name directly from backbone (instead of calling findGBIFName)