### PR TITLE
Kalkinnhold (lime/calcium content) integration

### DIFF
--- a/data/external/focalCovariates.csv
+++ b/data/external/focalCovariates.csv
@@ -36,3 +36,4 @@ distance_water,TRUE,TRUE,geonorge
 snow_cover,TRUE,TRUE,chelsa
 distance_roads,TRUE,TRUE,geonorge
 forest_line,TRUE,TRUE,nibio
+kalkinnhold,TRUE,TRUE,artsdatabanken

--- a/functions/get_artsdatabanken.R
+++ b/functions/get_artsdatabanken.R
@@ -1,0 +1,28 @@
+
+#' @title \emph{get_artsdatabanken}: This function downloads kalkinnhold data from an ADB endpoint
+
+#' @description This function downloads the kalkinnhold data from artsdatabanken and then applies named values to create proper categories.
+#'
+#' @return An aggregated raster containing kalkinnhold data for Norway.
+#'
+#' @import terra
+#' 
+
+
+get_artsdatabanken <- function() {
+
+  focalURL <- "https://data.artsdatabanken.no/Natur_i_Norge/Natursystem/Milj%C3%B8variabler/Kalkinnhold/grid.32633.tif"
+  message(sprintf("Downloading, %s raster from chelsa.", parameter))
+  raster <- terra::rast(focalURL)
+  rasterFactor <- as.factor(raster)
+  
+  catLegend <- data.frame(levels = c("0", "14", "154", "98", "210", "42"), 
+                          levelNames = c("no data", "svært kalkfattig", "litt kalkrik",
+                                         "svæk intermediær", "svært kalkrik",
+                                         "temmelig kalkfattig"))
+  levelsTable <- merge(levels(rasterFactor)[[1]], catLegend, by.x = "ID", by.y = "levels", all.x = TRUE)
+  levels(rasterFactor) <- levelsTable[,c(1,3)]
+  
+  return(rasterFactor)
+  
+}

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -117,6 +117,10 @@ if (dataSource == "geonorge") {
 ### 7. NIBIO ###
 } else if (dataSource == "nibio") {
   rasterisedVersion <- get_nibio(regionGeometryBuffer)
+
+### 8. Artsdatabanken ###
+} else if (dataSource == "artsdatabanken") {
+  rasterisedVersion <- get_artsdatabanken()
 }
 
 ### merge with requested download area to make missing data explicit


### PR DESCRIPTION
# Why have changes been made?

We want to integrate kalkinnhold from Artsdatabanken, this change introduces a function which does so.

# What changes have been made?

- data/external/focalCovariates.csv - Kalkinnhold added to list of covariates
- functions/get_artsdatabanken.R - Import geotiff from ADB, then assign named variables
- pipeline/import/utils/defineEnvSource.R - Add option to get_artsdatabanken