### PR TITLE
Soil type (losmasser) integration

### DIFF
--- a/data/external/focalCovariates.csv
+++ b/data/external/focalCovariates.csv
@@ -36,3 +36,5 @@ distance_water,TRUE,TRUE,geonorge
 snow_cover,TRUE,TRUE,chelsa
 distance_roads,TRUE,TRUE,geonorge
 forest_line,TRUE,TRUE,nibio
+kalkinnhold,TRUE,TRUE,artsdatabanken
+losmasse,TRUE,TRUE,ngu

--- a/functions/get_ngu.R
+++ b/functions/get_ngu.R
@@ -1,0 +1,34 @@
+
+#' @title \emph{get_ngu}: This function loads locally stored vector data and creates soil type (losmasse) data for a region
+
+#' @description This function loads locally stored vector data of soil types in Norway, and rasterizes it for a given region
+#'
+#' @return An aggregated raster containing elevation data for Norway.
+#'
+#' @import terra
+#' 
+
+
+
+get_ngu <- function(regionGeometry, projCRS) {
+  if (!file.exists("data/temp/ngu/Losmasse1000")) {
+    cat("Correct file does not exist. If you do not have access to the simplified losmasse N1000 file, contact sam.perrin@ntnu.no.")
+    return(NULL)
+  }
+  losmasseData <- read_sf(dsn = "data/temp/ngu/Losmasse1000/LosmFlate_N1000.shp") %>%
+    st_transform(projCRS)
+  
+  # Get elevation raster
+  # get  base raster with expanded buffer (as closest road or lake may be over county lines)
+  baseRasterDistance <- regionGeometry |>
+    st_buffer(40000) |>
+    st_transform(projCRS) |> 
+    vect()
+  baseWaterRaster <- terra::rast(extent = ext(baseRasterDistance), res = 1000, crs = projCRS)
+  baseWaterRaster$cellId <- paste0("cell", 1:ncell(baseWaterRaster))
+  
+  r <- terra::rasterize(losmasseData, baseWaterRaster, field = "jorda_navn", fun="max")
+
+  return(r)
+  
+}

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -117,6 +117,10 @@ if (dataSource == "geonorge") {
 ### 7. NIBIO ###
 } else if (dataSource == "nibio") {
   rasterisedVersion <- get_nibio(regionGeometryBuffer)
+
+### 9. NGU ###
+} else if (dataSource == "ngu") {
+  rasterisedVersion <- get_ngu(regionGeometry, projCRS)
 }
 
 ### merge with requested download area to make missing data explicit


### PR DESCRIPTION
# Why have changes been made?

Integration of soil type (losmasser) data into pipeline. Data comes from geonorge, though the direct link is currently not functioning and as such we need to provide the file.

# What changes have been made?

- data/external/focalCovariates.csv - Added in losmasser and kalkinnhold
- functions/get_ngu.R - Function which imports vector data from a locally stored shapefile and rasterizes it.
- pipeline/import/utils/defineEnvSource.R - Addition of ngu option to list.