### PR TITLE
Enabling of bash functionality for species model runs

### DIFF
--- a/pipeline/models/speciesModelRuns.R
+++ b/pipeline/models/speciesModelRuns.R
@@ -2,6 +2,25 @@
 
 #### MODEL RUNS ####
 
+###----------------------###
+### 0. Bash preparation ####
+###----------------------###
+
+args <- commandArgs(TRUE)
+
+# THis should only run if the script is being run from the command line
+if (length(args) != 0) {
+  # Set arguments
+  dateAccessed <- args[1]
+  modelRun <- args[2]
+  # Set the working directory
+  setwd("~/BioDivMapping")
+}
+
+# You can run this from the command line using for example
+# Rscript filePath/speciesModelRuns.R 2024-02-08 allSPecies
+
+
 ###-----------------###
 ### 1. Preparation ####
 ###-----------------###


### PR DESCRIPTION
# Why have changes been made?

To be able to run species models on the Sigma2 server we need to be able to submit the speciesModelRuns script as part of a shell script. The necessary arguments (model run type and date accessed) need to be inputtable as arguments.

# What changes have been made?

- pipeline/models/speciesModelRuns.R - the section at the start of this script means that the script can now be run using a bash script (see code example below) AND by sourcing it from other R scripts

Rscript filePath/speciesModelRuns.R 2024-02-08 allSpecies