### PR TITLE
Debug functional groups

### DIFF
--- a/functions/checkAndImportRast.R
+++ b/functions/checkAndImportRast.R
@@ -4,7 +4,7 @@ checkAndImportRast <- function(parameter, regionGeometry, dataPath, fileType = "
   raster <- NULL
   
   # List all files in the directory that match the parameter
-  filePattern <- paste0(parameter, sprintf("_.*\\.%s$", fileType))
+  filePattern <- paste0(parameter, sprintf(".*\\.%s$", fileType))
   fileList <- list.files(path = dataPath, pattern = filePattern, full.names = TRUE)
   
   # Check each file

--- a/functions/modelPreparation.R
+++ b/functions/modelPreparation.R
@@ -54,13 +54,10 @@ modelPreparation <- function(focalTaxa, focalCovariates, speciesData, redListMod
     
     # Combine species by functionalGroup if requested (else leave as separate)
     # identify species with data
-    uniqueTaxaSpecies <- unique(unlist(lapply(focalSpeciesDataRefined, function(ds){
-      as.character(ds$taxonKeyProject)
-    })))
-    
+    uniqueTaxaSpecies <- unique(bind_rows(focalSpeciesDataRefined)$taxonKeyProject)
     # identify functional groups in species with data for focal taxonomic group
     focalSpeciesWithData <- focalTaxa[focalTaxa$key %in% uniqueTaxaSpecies &  # species with data
-                                        focalTaxa$taxa %in% focalTaxa,]  # and of focal taxa (in case same species in different taxa)
+                                        focalTaxa$taxa %in% focalTaxon,]  # and of focal taxa (in case same species in different taxa)
     # if any species are to be modelled as functional groups
     if(any(!is.na(focalSpeciesWithData$functionalGroup) & focalSpeciesWithData$functionalGroup != "")){
       # update data


### PR DESCRIPTION
# Why have changes been made?

- would not merge functional groups because taxa keys are now stored as numeric (used to be character) and we changed use of "focalTaxa" to "focalTaxon", which wasn't updated in functional group merging.
- also made search for environmental covariates a bit more generic by getting rid of "_" in search pattern.

# What changes have been made?
- functions/checkAndImportRast.R - [remove "_" for more generic search](https://github.com/gjearevoll/BioDivMapping/commit/33351fcd209d5630941b7e02ec0840076e35e945)
- functions/modelPreparation.R - taxa key is now numeric, and use "focalTaxon" instead of "focalTaxa"
