### PR TITLE
Met data bug fix

### DIFF
--- a/functions/get_met.R
+++ b/functions/get_met.R
@@ -3,8 +3,9 @@
 
 #' @description Chelsa has a range of climate data - this function downloads them based on the parameter chosen. All dataset links can be found here https://envicloud.wsl.ch/#/?prefix=chelsa%2Fchelsa_V2%2FGLOBAL%2F.
 #'
-#' @param parameter The chosen parameter. The function has the relevant link to the dataset built in.
-#' @param dataPath The folder where the downloaded nc file should be saved.
+#' @param focalParameter The chosen parameter. The function has the relevant link to the dataset built in.
+#' @param projCRS Project crs
+#' @param ncPath The folder where the downloaded nc file should be saved.
 #'
 #' @import terra
 #' 
@@ -23,13 +24,17 @@ get_met <- function(focalParameter, projCRS, ncPath = NA) {
     filePath <- paste0(ncPath, "/rr_normal_jja_1991-2020.nc")
   }
   
+  if (!(file.exists(filePath))) {
+    stop("nc file not found at specified path. Can be found at ",focalURL, ". File name should be ", filePath, ".")
+  }
+  
   if (is.na(ncPath)) {
     message("'ncPath' not specified, please select the ", focalParameter," nc file. Data can be downloaded from ", focalURL, 
             ". Select the HTTP server data.")
     filePath <- file.choose()
   }
   
-  message(sprintf("Uploadingras %s raster", focalParameter))
+  message(sprintf("Uploading %s raster", focalParameter))
   rastNC <- terra::rast(filePath) %>%
     terra::project(projCRS)
 

--- a/functions/get_met.R
+++ b/functions/get_met.R
@@ -13,17 +13,24 @@
 
 
 
-get_met <- function(parameter, dataPath) {
-  if (parameter == "summer_temperature") {
-    focalURL <- "https://thredds.met.no/thredds/fileServer/KSS/Gridded_climate_normals_1991-2020/temperature/tm_normal_jja_1991-2020.nc"
-  } else if (parameter == "summer_precipitation") {
-    focalURL <- "https://thredds.met.no/thredds/fileServer/KSS/Gridded_climate_normals_1991-2020/precipitation/rr_normal_jja_1991-2020.nc"
-  }
-  message(sprintf("Downloading, %s raster from met", parameter))
-  file_path <- paste0(dataPath, "/", parameter, ".nc")
-  download.file(focalURL, destfile = file_path)
+get_met <- function(focalParameter, projCRS, ncPath = NA) {
   
-  rastNC <- terra::rast(file_path) %>%
+  if (focalParameter == "summer_temperature") {
+    focalURL <- "https://thredds.met.no/thredds/catalog/KSS/Gridded_climate_normals_1991-2020/temperature/catalog.html?dataset=KSS/Gridded_climate_normals_1991-2020/temperature/tm_normal_jja_1991-2020.nc"
+    filePath <- paste0(ncPath, "/tm_normal_jja_1991-2020.nc")
+  } else if (focalParameter == "summer_precipitation") {
+    focalURL <- "https://thredds.met.no/thredds/catalog/KSS/Gridded_climate_normals_1991-2020/precipitation/catalog.html?dataset=KSS/Gridded_climate_normals_1991-2020/precipitation/rr_normal_jja_1991-2020.nc"
+    filePath <- paste0(ncPath, "/rr_normal_jja_1991-2020.nc")
+  }
+  
+  if (is.na(ncPath)) {
+    message("'ncPath' not specified, please select the ", focalParameter," nc file. Data can be downloaded from ", focalURL, 
+            ". Select the HTTP server data.")
+    filePath <- file.choose()
+  }
+  
+  message(sprintf("Uploadingras %s raster", focalParameter))
+  rastNC <- terra::rast(filePath) %>%
     terra::project(projCRS)
 
   return(rastNC)

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -135,7 +135,7 @@ if (dataSource == "geonorge") {
 
 ### 10. MET ###  
 } else if (dataSource == "met") {
-  rasterisedVersion <- get_met(focalParameter, dataPath)
+  rasterisedVersion <- get_met(focalParameter, projCRS, ncPath)
 }  
 
 ### merge with requested download area to make missing data explicit


### PR DESCRIPTION
# Why have changes been made?

The met data link which was used before does not work as an automatic download link. I've changed the function so that instead it demands a manual download and the function needs to specify where this download can be found.

# What changes have been made?

- functions/get_met.R - Function asks for manual download, takes a parameter argument to find file
- pipeline/import/utils/defineEnvSource.R - Extra argument for get_met added
