### PR TITLE
Minor updates - habitat heterogeneity defined by res, ANO data import bug

### DIFF
--- a/functions/importANOData.R
+++ b/functions/importANOData.R
@@ -26,7 +26,7 @@ importANOData <- function(destinationFolder, regionGeometry, focalTaxon,
                            destfile=paste0(destinationFolder, "/naturovervaking_eksport.gdb.zip"), mode = "wb")
   unzip(paste0(destinationFolder, "/naturovervaking_eksport.gdb.zip"), 
         exdir = destinationFolder)
-  ANOUnzippedFolder <- paste0(destinationFolder, "/Naturovervaking_eksport.gdb")
+  ANOUnzippedFolder <- paste0(destinationFolder, "/naturovervaking_eksport.gdb")
   
   # Import geometry data to later match to species occurrnece
   ANOPoints <- st_read(ANOUnzippedFolder, layer="ANO_SurveyPoint")

--- a/pipeline/import/utils/defineEnvSource.R
+++ b/pipeline/import/utils/defineEnvSource.R
@@ -114,7 +114,8 @@ if (dataSource == "geonorge") {
     message("Calculating heterogeneity based on raster data.")
     croppedRaster <- crop(rasterisedVersion, ext(terra::project(regionGeometryBuffer, rasterisedVersion)))
     library(rasterdiv)
-    rasterisedVersion <- Shannon(croppedRaster, window = 5)
+    cropFactor <- ifelse(res > 1000, 3, ifelse(res <= 100, 9, 5))
+    rasterisedVersion <- Shannon(croppedRaster, window = cropFactor)
     }
   
 ### 6. Chelsa ###  


### PR DESCRIPTION
# Why have changes been made?

Two minor updates based on a recent run have been made and are described below.

# What changes have been made?

- functions/importANOData.R - For some reason a new ANO upload changed the capitalisation of one of the files. This has been fixed on our end now.
- pipeline/import/utils/defineEnvSource.R - We now define the number of cells to use when calculating habitat heterogeneity based on the resolution we're after.