### PR TITLE
Priors to mainScript, mask covs to regionGeometry, predict using user res/crs, minor bugs

### DIFF
--- a/masterScript.R
+++ b/masterScript.R
@@ -43,7 +43,10 @@ redListThreshold <- 30
 # which categories are to be used for filtering/analysing red list species
 redListCategories <- c("VU", "EN", "CR")
 # the type of model that will be fitted to the data
-modelRun <- "redListSpecies"  # or "redListRichness", "richness", or "allSpecies"
+modelRun <- "redListSpecies"  # one of: "redListSpecies", "redListRichness", "richness", or "allSpecies"
+# model priors
+prior.range <- c(1000, 0.05)
+prior.sigma <- c(3, 0.05)
 
 # Let's get started! The first script initialiseRepository.R, which will create 
 # a folder for the specified dateAccessed, filters focalTaxa for taxa to be analyzed 

--- a/pipeline/import/environmentalImport.R
+++ b/pipeline/import/environmentalImport.R
@@ -129,12 +129,12 @@ for(parameter in seq_along(selectedParameters)) {
 ###------------------------###
 ### 3. Data Consolidation ####
 ###------------------------###
-
 # Crop, match projections and compile raster layers into one object
 parametersCropped <- parameterList |> 
   lapply(function(x) {
+    regionExt <- as.polygons(terra::project(regionGeometryBuffer, x), extent = TRUE)
     # Crop each covariate to extent of regionGeometryBuffer
-    out <- terra::crop(x, as.polygons(terra::project(regionGeometryBuffer, x), extent = TRUE), snap = "out", mask = TRUE)
+    out <- terra::crop(x, regionExt, snap = "out")
     # Project all rasters to baseRaster and combine
     if(is.factor(x)) {
       # project categorical rasters

--- a/pipeline/import/environmentalImport.R
+++ b/pipeline/import/environmentalImport.R
@@ -95,6 +95,13 @@ regionGeometryBuffer <- st_union(if(exists("myMesh")) {
 # define working project raster 
 baseRaster <- terra::rast(extent = ext(regionGeometryBuffer), res = res, crs = projCRS)
 
+# rasterise regionGeometry
+regionGeometryRast <- regionGeometry |>
+  st_as_sf() |>
+  st_transform(projCRS) |> 
+  vect() |>
+  terra::rasterize(baseRaster, FUN = "mode") 
+
 # download environmental data
 parameterList <- list()
 
@@ -143,7 +150,8 @@ parametersCropped <- parameterList |>
       out
     } else {
       # project & scale continuous rasters
-      terra::project(out, baseRaster) |>
+      ifel(is.na(regionGeometryRast), NA,
+           terra::project(out, baseRaster)) |>
         scale()  
     }}) |>  
   rast() |>  # combine raster layers

--- a/pipeline/import/initialiseRepository.R
+++ b/pipeline/import/initialiseRepository.R
@@ -69,7 +69,9 @@ if(file.exists(paste0(folderName,"/controlPars.RDS"))){
                       myMesh = myMesh,
                       redListCategories = redListCategories,
                       redListThreshold = redListThreshold,
-                      modelRun = modelRun)
+                      modelRun = modelRun,
+                      prior.range = prior.range,
+                      prior.sigma = prior.sigma)
   # save
   saveRDS(controlPars, paste0(folderName,"/controlPars.RDS"))
 }

--- a/pipeline/integration/utils/metadataProduction.Rmd
+++ b/pipeline/integration/utils/metadataProduction.Rmd
@@ -46,7 +46,7 @@ infoNames <- c("Date",
                "Total species",
                "Total datasets used", 
                "DOI")
-info <- c(dateAccessed, paste(focalTaxa, collapse = ", "), level, region, totalSpecies,
+info <- c(dateAccessed, paste(focalTaxa, collapse = ", "), level,  paste(region, collapse = ", "), totalSpecies,
           length(unique(processedDataDF$dsName)), downloadKey$doi)
 basicInfo <- data.frame(Characteristic = infoNames, Value = info)
 knitr::kable(basicInfo)

--- a/pipeline/models/speciesModelRuns.R
+++ b/pipeline/models/speciesModelRuns.R
@@ -57,7 +57,8 @@ if (length(args) != 0) {
 
 # Import species list
 focalTaxa <- read.csv(paste0(folderName, "/focalTaxa.csv"), header = T)
-redList <- readRDS(paste0(folderName, "/redList.RDS"))
+redList <- if(modelRun %in% c("allSpecies")) NULL else
+  readRDS(paste0(folderName, "/redList.RDS"))
 
 # Import datasets
 regionGeometry <- readRDS(paste0(folderName, "/regionGeometry.RDS"))

--- a/pipeline/models/speciesModelRuns.R
+++ b/pipeline/models/speciesModelRuns.R
@@ -70,7 +70,7 @@ projCRS <- readRDS(paste0(tempFolderName,"/projCRS.RDS"))
 # Define speciesData based on run type and create predictionData
 modelSpeciesData <- refineSpeciesData(speciesData, modelRun)
 segmentation <- modelRun %in% c("richness", "redListRichness")
-predictionData <- createPredictionData(c(res/1000, res/1000), regionGeometry)
+predictionData <- createPredictionData(c(res, res), regionGeometry, projCRS)
 
 
 # Prepare models

--- a/pipeline/models/speciesModelRuns.R
+++ b/pipeline/models/speciesModelRuns.R
@@ -117,8 +117,9 @@ for (i in seq_along(workflowList)) {
 
   # Add model characteristics (mesh, priors, output)
   workflow$addMesh(cutoff= myMesh$cutoff, max.edge=myMesh$max.edge, offset= myMesh$offset)
-  workflow$specifySpatial(prior.range = c(300000, 0.05),
-                          prior.sigma = c(500, 0.2)) #100
+  workflow$specifySpatial(prior.range = prior.range,
+                          prior.sigma = prior.sigma)
+  # workflow$workflowOutput(c('Predictions', 'Bias', 'Model', 'Maps'))
   workflow$workflowOutput(modelOutputs)
   workflow$modelOptions(INLA = list(num.threads = 12, control.inla=list(int.strategy = 'eb', cmin = 0),safe = TRUE),
                         Richness = list(predictionIntercept = predictionDatasetShort))


### PR DESCRIPTION
# Why have changes been made?
- priors significantly affect results and should be explicitly defined up front in masterScript. values of priors have also been made more reasonable.
- covariates are scaled based on values in their respective layers, however, some have data outside of norway (eg corine), some convert it all to 0 (eg road density), some is all NA (eg met weather), leading to inconsistent standardisation.
- all spatial processing used res and crs defined in masterScript, except for prediction, this now uses the parameters as defined in masterScript.

# What changes have been made?
- masterScript.R - define prior.range and prior.sigma
- pipeline/import/initialiseRepository.R - add prior.range and prior.sigma to controlPars.RDS
- pipeline/import/environmentalImport.R - convert regionGeometry to raster, and use it to set all rasters outside of regionGeometry to NA
- pipeline/integration/utils/metadataProduction.Rmd - bug: split region with comma, in cases where multiple regions were used to define regionGeometry.
- pipeline/models/speciesModelRuns.R - use res and projCRS as defined yn masterScript for predictionData. use prior.range & prior.sigma from controsPars.RDS. bug: if modelRun = "allSpecies", redList should be NULL