### PR TITLE
Species selection bug fix

### DIFF
--- a/functions/modelPreparation.R
+++ b/functions/modelPreparation.R
@@ -93,6 +93,11 @@ modelPreparation <- function(focalTaxa, focalCovariates, speciesDataAll, redList
         dat <- speciesData[[x]] %>%
           dplyr::filter(taxa %in% focalTaxon)
         
+        if ("individualCount" %in% colnames(dat)) {
+          dat <- dat %>%
+            filter(individualCount == 1)
+        }
+        
         # Extract the species Info
         if(nrow(dat) > 0){
           data.frame(datasetName = speciesDataNames[[x]],

--- a/pipeline/parallelModelRun/modelPreparationParallelRun.R
+++ b/pipeline/parallelModelRun/modelPreparationParallelRun.R
@@ -153,6 +153,7 @@ for(iter in 1:1){
   
   listSegments[[iter]] <- focalTaxaRun
   if (grepl("vascularPlants", focalTaxa$taxa[iter])) {saveRDS(focalTaxaRun, paste0(folderName, "/segmentList", focalTaxa$taxa[iter] ,".RDS"))}
+  rm("modelSpeciesData")
   save.image(file = paste0(folderName,"/workspaces/",  focalTaxa[iter, 1], "workflowWorkspace.RData"))
 }
 


### PR DESCRIPTION
# Why have changes been made?

- An update created an error whereby all absences were included in determining whether or not a species had enough observations (50) to be used. We want only presences to be used.

# What changes have been made?

- functions/modelPreparation.R - Simple fix. Species counts now don't include absences.

# Additional changes
- pipeline/parallelModelRun/modelPreparationParallelRun.R - modelSpeciesData was not used in any further pipeline scripts and is therefore deleted so as not to fill up the workspace file with useless garbage.
