### PR TITLE
Save processed data locally

### DIFF
--- a/functions/processFieldNotes.R
+++ b/functions/processFieldNotes.R
@@ -101,5 +101,6 @@ processFieldNotes <- function(focalEndpoint, tempFolderName, datasetName, region
   newDataset <- newDataset %>%
     dplyr::select(acceptedScientificName, individualCount, geometry, dataType, taxa, year, taxonKeyProject) %>%
     filter(!is.na(acceptedScientificName))
+  saveRDS(newDataset, paste0(tempFolderName,"/", datasetName ,"/processedDataset.RDS"))
   return(newDataset)
 }

--- a/functions/processFieldNotesEvent.R
+++ b/functions/processFieldNotesEvent.R
@@ -124,5 +124,6 @@ processFieldNotesEvent <- function(focalEndpoint, tempFolderName, datasetName, r
   newDataset <- newDataset %>%
     dplyr::select(acceptedScientificName, individualCount, geometry, dataType, taxa, year, taxonKeyProject) %>%
     filter(!is.na(acceptedScientificName))
+  saveRDS(newDataset, paste0(tempFolderName,"/", datasetName ,"/processedDataset.RDS"))
   return(newDataset)
 }

--- a/functions/processFieldNotesOslo.R
+++ b/functions/processFieldNotesOslo.R
@@ -95,5 +95,6 @@ processFieldNotesOslo <- function(focalEndpoint, tempFolderName, datasetName, re
   newDataset <- newDataset %>%
     dplyr::select(acceptedScientificName, individualCount, geometry, dataType, taxa, year, taxonKeyProject) %>%
     filter(!is.na(acceptedScientificName))
+  saveRDS(newDataset, paste0(tempFolderName,"/", datasetName ,"/processedDataset.RDS"))
   return(newDataset)
 }

--- a/pipeline/integration/utils/defineProcessing.R
+++ b/pipeline/integration/utils/defineProcessing.R
@@ -4,8 +4,14 @@
 # This script assigns different functions to the datasets that they were created for. The functions herein
 # reside in functions and begin with "process".
 
+# 0. Check whether a pre-processed version of this dataset exists
+dataFileName <- paste0(tempFolderName,"/", datasetName ,"/processedDataset.RDS")
+if (file.exists(dataFileName)) {
+  cat("\tPre-processed version used\n")
+  newDataset <- readRDS(dataFileName)
+  
 # 1. The national insect Monitoring in Norway dataset
-if (dataType == "insectMonitoring") {
+} else if (dataType == "insectMonitoring") {
   focalEndpoint <- metadata$DWCEndpoint[metadata$name == datasetName]
   newDataset <- processNationalInsectMonitoring(focalData, focalEndpoint, tempFolderName)
   


### PR DESCRIPTION
# Why have changes been made?

- To avoid multiple downloads and processing of the same external data, once a dataset has been processed that processed version is saved locally in the corresponding "temp" file

# What changes have been made?

- functions/processFieldNotes.R - A saveRDS function has been added to the end of all of these scripts 
- pipeline/integration/utils/defineProcessing.R - Looks for a locally saved file before downloading externally

