### PR TITLE
Predictor species introduction

### DIFF
--- a/data/external/focalTaxa.csv
+++ b/data/external/focalTaxa.csv
@@ -1,33 +1,33 @@
-"taxa","key","level","scientificName","include","functionalGroup","predictionDataset","summer_precipitation","summer_temperature","snow_cover","aspect","slope","kalkinnhold","net_primary_productivity","land_cover_corine","human_density","distance_roads","distance_water","forest_line","habitat_heterogeneity","sampleSize"
-"amphibiansReptiles",11592253,"class","Squamata",FALSE,NA,"",TRUE,TRUE,FALSE,FALSE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,1
-"amphibiansReptiles",131,"class","Amphibia",FALSE,NA,"",TRUE,TRUE,FALSE,FALSE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,1
-"spiders",367,"class","Arachnida",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"beetles",1470,"order","Coleoptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"cockroaches",800,"order","Blattodea",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"snakeflies",786,"order","Raphidioptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"scorpionflies",1000,"order","Mecoptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"bugs",809,"order","Hemiptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"netWingedInsects",1501,"order","Neuroptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"grasshopperLikeInsects",1458,"order","Orthoptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"earwigs",1224,"order","Dermaptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"butterfliesMoths",797,"order","Lepidoptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"flies",811,"order","Diptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"hymenopterans",1457,"order","Hymenoptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"aquaticInsects",1225,"order","Ephemeroptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"aquaticInsects",1003,"order","Tricoptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"aquaticInsects",787,"order","Plecoptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"aquaticInsects",789,"order","Odonata",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"aquaticInsects",1451,"order","Megaloptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1
-"vascularPlants",7707728,"phylum","Tracheophyta",TRUE,NA,"ANOData",TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,0.25
-"mosses",35,"phylum","Bryophyta",FALSE,NA,"",TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,1
-"mammals",803,"order","Soricomorpha",FALSE,NA,"",FALSE,TRUE,TRUE,FALSE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,1
-"mammals",785,"order","Lagomorpha",FALSE,NA,"",FALSE,TRUE,TRUE,FALSE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,1
-"mammals",1459,"order","Rodentia",FALSE,NA,"",FALSE,TRUE,TRUE,FALSE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,1
-"mammals",829,"order","Erinaceomorpha",FALSE,NA,"",FALSE,TRUE,TRUE,FALSE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,1
-"mammals",5307,"family","Mustelidae",FALSE,NA,"",FALSE,TRUE,TRUE,FALSE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,1
-"fungi",5,"kingdom","Fungi",FALSE,NA,"",TRUE,TRUE,TRUE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE,FALSE,FALSE,TRUE,TRUE,0.25
-"lichens",NA,"polyphyla","Lichens",FALSE,NA,"",TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,0.25
-"groundNestingBirds",NA,"polyphyla","Ground-Nesting Birds",FALSE,NA,"",TRUE,TRUE,TRUE,TRUE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,1
-"woodpeckers",9333,"family","Picidae",FALSE,NA,"",TRUE,TRUE,TRUE,TRUE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,1
-"birds",212,"class","Aves",FALSE,NA,"",TRUE,TRUE,TRUE,TRUE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,300
-"bats",734,"order","Chiroptera",FALSE,NA,"",TRUE,TRUE,FALSE,FALSE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,1
+"taxa","key","level","scientificName","include","functionalGroup","predictionDataset","summer_precipitation","summer_temperature","snow_cover","aspect","slope","kalkinnhold","net_primary_productivity","land_cover_corine","human_density","distance_roads","distance_water","forest_line","habitat_heterogeneity","sampleSize","predictorSpecies"
+"amphibiansReptiles",11592253,"class","Squamata",FALSE,NA,"",TRUE,TRUE,FALSE,FALSE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"amphibiansReptiles",131,"class","Amphibia",FALSE,NA,"",TRUE,TRUE,FALSE,FALSE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"spiders",367,"class","Arachnida",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"beetles",1470,"order","Coleoptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"cockroaches",800,"order","Blattodea",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"snakeflies",786,"order","Raphidioptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"scorpionflies",1000,"order","Mecoptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"bugs",809,"order","Hemiptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"netWingedInsects",1501,"order","Neuroptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"grasshopperLikeInsects",1458,"order","Orthoptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"earwigs",1224,"order","Dermaptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"butterfliesMoths",797,"order","Lepidoptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"flies",811,"order","Diptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"hymenopterans",1457,"order","Hymenoptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"aquaticInsects",1225,"order","Ephemeroptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"aquaticInsects",1003,"order","Tricoptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"aquaticInsects",787,"order","Plecoptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"aquaticInsects",789,"order","Odonata",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"aquaticInsects",1451,"order","Megaloptera",FALSE,NA,"National insect monitoring in Norway",TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"vascularPlants",7707728,"phylum","Tracheophyta",TRUE,NA,"ANOData",TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,0.25,"Lysimachia_europaea"
+"mosses",35,"phylum","Bryophyta",FALSE,NA,"",TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,1,NULL
+"mammals",803,"order","Soricomorpha",FALSE,NA,"",FALSE,TRUE,TRUE,FALSE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,1,NULL
+"mammals",785,"order","Lagomorpha",FALSE,NA,"",FALSE,TRUE,TRUE,FALSE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,1,NULL
+"mammals",1459,"order","Rodentia",FALSE,NA,"",FALSE,TRUE,TRUE,FALSE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,1,NULL
+"mammals",829,"order","Erinaceomorpha",FALSE,NA,"",FALSE,TRUE,TRUE,FALSE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,1,NULL
+"mammals",5307,"family","Mustelidae",FALSE,NA,"",FALSE,TRUE,TRUE,FALSE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,1,NULL
+"fungi",5,"kingdom","Fungi",FALSE,NA,"",TRUE,TRUE,TRUE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE,FALSE,FALSE,TRUE,TRUE,0.25,NULL
+"lichens",NA,"polyphyla","Lichens",FALSE,NA,"",TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,0.25,NULL
+"groundNestingBirds",NA,"polyphyla","Ground-Nesting Birds",FALSE,NA,"",TRUE,TRUE,TRUE,TRUE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"woodpeckers",9333,"family","Picidae",FALSE,NA,"",TRUE,TRUE,TRUE,TRUE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,1,NULL
+"birds",212,"class","Aves",FALSE,NA,"",TRUE,TRUE,TRUE,TRUE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,300,NULL
+"bats",734,"order","Chiroptera",FALSE,NA,"",TRUE,TRUE,FALSE,FALSE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,1,NULL

--- a/functions/modelPreparation.R
+++ b/functions/modelPreparation.R
@@ -209,6 +209,13 @@ modelPreparation <- function(focalTaxa, focalCovariates, speciesDataAll, regionG
       
       # Get the list of all the species      
       speciesCounts <- sort(table(unlist(lapply(speciesData, FUN = function(x) {
+        if ("individualCount" %in% colnames(x)) {
+          presenceData <- x[x$individualCount == 1,]
+        } else {presenceData <- x}
+        presenceData$simpleScientificName
+      }))), TRUE)
+      
+      speciesCountsAll <- sort(table(unlist(lapply(speciesData, FUN = function(x) {
         x$simpleScientificName
       }))), TRUE)
       
@@ -254,8 +261,13 @@ modelPreparation <- function(focalTaxa, focalCovariates, speciesDataAll, regionG
         # y <- 
         speciesCounts[segmentedList[[x]]]
       })
+      nRecords <- lapply(as.list(seq_along(segmentedList)), function(x){
+        # y <- 
+        speciesCountsAll[segmentedList[[x]]]
+      })
 
       names(nOccurences) <- names(segmentedList)
+      names(nRecords) <- names(segmentedList)
       speciesLists[[focalTaxon]] <- segmentedList
       speciesDataList[[focalTaxon]] <- speciesData
       saveRDS(nOccurences, paste0(tempFolderName, "/",focalTaxon,"numberOfOccurrences.RDS"))
@@ -326,6 +338,7 @@ modelPreparation <- function(focalTaxa, focalCovariates, speciesDataAll, regionG
     speciesList <- unique(do.call(c, speciesList))
     
     print(paste("Number of occurence records for", focalTaxon, "is", sum(nOccurences[[focalTaxon]])))
+    print(paste("Number of totalrecords for", focalTaxon, "is", sum(nRecords[[focalTaxon]])))
     # Initialise workflow, creating folder for model result storage
     workflow <- startWorkflow(
       Projection = st_crs(crs)$proj4string,

--- a/pipeline/integration/speciesDataProcessing.R
+++ b/pipeline/integration/speciesDataProcessing.R
@@ -169,7 +169,7 @@ processedDataCompiled <- do.call(rbind, lapply(1:length(maskedData), FUN = funct
   dataset <- maskedData[[x]]
   datasetName <- names(maskedData)[x]
   datasetType <- unique(dataset$dataType)
-  if (datasetType == "PO") {
+  if (!("individualCount" %in% colnames(dataset))) {
     dataset$individualCount <- 1
   }
   datasetShort <- dataset[, c("acceptedScientificName", "individualCount", "geometry", "taxa", "year", "dataType", 

--- a/pipeline/parallelModelRun/modelPreparationParallelRun.R
+++ b/pipeline/parallelModelRun/modelPreparationParallelRun.R
@@ -119,6 +119,7 @@ listSegments <- list()
 
 # Prepare models
 for(iter in 1:nrow(focalTaxa)){
+  predictorSpecies <- focalTaxa$predictorSpecies[iter]
   workflowList <- modelPreparation(focalTaxa[iter, ], focalCovariates, speciesData, 
                                    regionGeometry = regionGeometry,
                                    modelFolderName = modelFolderName, 
@@ -129,7 +130,7 @@ for(iter in 1:nrow(focalTaxa)){
                                    speciesOccurrenceThreshold = speciesOccurrenceThreshold,
                                    datasetOccurrenceThreshold = datasetOccurrenceThreshold, 
                                    mergeAllDatasets = TRUE,
-                                   richness = TRUE)
+                                   richness = TRUE, predictorSpecies = predictorSpecies)
   focalTaxaRun <- names(workflowList)
   
   

--- a/pipeline/parallelModelRun/scheduleParallelRun.R
+++ b/pipeline/parallelModelRun/scheduleParallelRun.R
@@ -65,8 +65,9 @@ print(predictionDatasetShort)
 # myMesh$cutoff <- 3*1000
 # myMesh$offset <- c(20, 100) * 1000
 # myMesh$max.edge <- c(200, 500) * 1000
-# meshToUse <- meshTest(myMesh, regionGeometry, crs = crs, print = TRUE)
 # fm_int(domain = meshToUse, samplers = regionGeometry, int.args = list(method = 'direct', nsub1 = 15, nsub2 = 15))
+meshToUse <- meshTest(myMesh, regionGeometry, crs = crs, print = TRUE)
+
 
 # Add model characteristics (mesh, priors, output)
 workflow$addMesh(Object = meshToUse)


### PR DESCRIPTION
# Why have changes been made?

- To ensure consistency when converting species intensity into species likelihood of occurrence, we need to have a common species across all segments for a taxa. This needs to be chosen manually - species should have good coverage throughout Norway - and inserted into the focalTaxa file.

# What changes have been made?

- data/external/focalTaxa.csv - Column added for predictor species
- functions/modelPreparation.R - Predictor species now kept across all segments
- pipeline/parallelModelRun/modelPreparationParallelRun.R - Predictor species introduced

Other minor bug fixes:
- functions/modelPreparation.R - Now shows all species occurrences as well as all species records (incl. absences)
- pipeline/integration/speciesDataProcessing.R - Different method of identifying presence only data
- pipeline/parallelModelRun/scheduleParallelRun.R - Quick bug fix whereby mesh wasn't defined properly
