### PR TITLE
Add new processing functions

### DIFF
--- a/data/external/metadataSummary.csv
+++ b/data/external/metadataSummary.csv
@@ -28,9 +28,9 @@ e4deab67-0998-4140-b573-0ba1f624eb3e,"Fungarium, Oslo (O) UiO",presenceOnly,FALS
 d0aa984e-c6d3-45ee-8fc0-df1df8f4126b,"Vascular plant herbarium, The Arctic University Museum of Norway (TROM)",presenceOnly,FALSE
 88ea9eca-96ad-4a5a-8a01-99a4acabe050,"Vascular Plants, Observations, Oslo (O)",fieldNotesOslo,FALSE
 30bc94f2-50aa-4688-8e87-a8e11d3d69ff,Vascular plant herbarium (KMN) UiA,presenceOnly,FALSE
-33591b80-0e31-480c-82ce-2f57211b10e6,Freshwater benthic invertebrates ecological collection NTNU University Museum,fieldNotesEvent,FALSE
+33591b80-0e31-480c-82ce-2f57211b10e6,Freshwater benthic invertebrates ecological collection NTNU University Museum,NTNUFreshwater,FALSE
 6ce9819a-d82b-41e1-9059-0dd201f15993,"Entomological collections, UiB",presenceOnly,FALSE
-edd9b710-f3bb-4c49-9fa5-724cd4ecfc7d,Freshwater pelagic invertebrates ecological collection NTNU University Museum,fieldNotesEvent,FALSE
+edd9b710-f3bb-4c49-9fa5-724cd4ecfc7d,Freshwater pelagic invertebrates ecological collection NTNU University Museum,NTNUFreshwater,FALSE
 c5fe763f-6851-4610-bdc3-67143540be67,Effects of vegetation clearing and dead wood on beetles in power line clearings southeast Norway,fieldNotesEvent,FALSE
 67780c67-2157-4809-8b51-0b47a7ae8d3b,Beetles from Old Spruce Forests in Southern Norway 2019,NA,FALSE
 fbcbdda3-abc2-47ae-9b8e-b75ab1128d54,Saproxylic and herbivorous beetle species in old near-natural and old managed forests in south-eastern Norway,fieldNotesEvent,FALSE
@@ -135,4 +135,8 @@ ed391b37-d3d3-4efd-9419-1583c39c0c87,NHMO DNA Bank Fungi and Lichens collection,
 ea0bb0f7-84cc-4541-96a2-837003f31d99,Norwegian freshwater lake fish inventory,"freshwaterFishInventory",FALSE
 f372a689-31ef-46af-9552-78f90cab9a9a,Salmonidae in streams,"presenceOnly",FALSE
 df12ca07-f133-4550-ab3b-fde13f0e76ba,"Notebook, general observations","presenceOnly",FALSE
-46293000-ddd1-4c32-a1e7-b5e793223ecd,"Vannmiljø - artsforekomster","presenceOnly",FALSE
+46293000-ddd1-4c32-a1e7-b5e793223ecd,"Vannmiljø - artsforekomster","vannmiljo",FALSE
+"9e404d5d-64ce-4887-a0ae-150298c9a562","Polliland - Bees in semi-natural grasslands","presenceOnly",FALSE
+"7e380070-f762-11e1-a439-00145eb45e9a","Natural History Museum (London) Collection Specimens","presenceOnly",FALSE
+"66276aee-900b-4259-bc7a-bcfbcb6d56b8","NHMO DNA Bank Arthropod collection","presenceOnly",FALSE
+"edb656a0-71ad-418d-afb1-c5584283ba47","Arealrepresentativ naturovervåkning (ANO)","ANOData",FALSE

--- a/functions/processANOData.R
+++ b/functions/processANOData.R
@@ -11,24 +11,70 @@
 #' 
 
 
-processANOData <- function(ANODataset, crs) {
+processANOData <- function(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon, crs, yearToStart) {
+  
+
+  # Download and unzip file in temp folder
+  #ptions(timeout=100)
+  download.file(focalEndpoint, paste0(tempFolderName,"/", datasetName ,".zip"), mode = "wb")
+  unzip(paste0(tempFolderName,"/", datasetName ,".zip"), exdir = paste0(tempFolderName,"/",  datasetName))
+  
+  # Load in event and occurrence data
+  events <- read.delim(paste0(tempFolderName,"/", datasetName ,"/event.txt")) %>%
+    filter(coordinateUncertaintyInMeters < coordUncertainty)
+  occurrence <- read.delim(paste0(tempFolderName,"/", datasetName ,"/occurrence.txt"))
+  
+  # Get all main events from data and get event table for just these events
+  mainEvents <- unique(substr(events$parentEventID,1,13))
+  eventTable <- events[events$eventID %in% mainEvents, c("eventID", "decimalLatitude", "decimalLongitude")]
+  eventTable$year <- substr(eventTable$eventID, 5,8)
+  
+  # Now remove all events fro before start eyar
+  eventTable <- eventTable[eventTable$year >= yearToStart,]
+  eventLocationsSF <- st_as_sf(eventLocations,                         
+                               coords = c("decimalLongitude", "decimalLatitude"),
+                               crs = "+proj=longlat +ellps=WGS84")
+  eventLocationsSF <- st_transform(eventLocationsSF, crs = crs)
+  eventLocationsSF <- st_intersection(eventLocationsSF, regionGeometry)
+  
+  # Get occurrences down only to ANO squares and species found
+  occurrenceShort <- occurrence[substr(occurrence$eventID,1,13) %in% unique(eventLocationsSF$eventID), c("scientificName", "eventID")]
+  occurrenceShort$eventID <- substr(occurrenceShort$eventID,1,13)
+  occurrenceShort$individualCount <- 1
+  occurrenceShort <- occurrenceShort[!duplicated(occurrenceShort),]
+  
+  # Build a species table
+  surveyedSpecies <- unique(occurrenceShort$scientificName)
+  speciesLegend <- data.frame(surveyedSpecies = surveyedSpecies, 
+                              acceptedScientificName = sapply(surveyedSpecies, FUN = findGBIFName),
+                              taxonKey = sapply(surveyedSpecies, FUN = function(x) {taxaCheck(x, focalTaxon$key)})) %>%
+    filter(!is.na(taxonKey)) %>%
+    filter(!is.na(acceptedScientificName))
+  if (nrow(speciesLegend) == 0) {return(NULL)}
+  
+  # Create table with all data combinations that we can match to
+  eventTable <- expand.grid(scientificName = speciesLegend$surveyedSpecies, eventID = unique(eventLocationsSF$eventID))
+  eventTable <- merge(eventTable, occurrenceShort, all.x = TRUE, by = c("eventID", "scientificName"))
+  
+  # Add details in to final table
+  eventTable$geometry <- eventLocationsSF$geometry[match(eventTable$eventID, eventLocationsSF$eventID)]
+  eventTable$year <- substr(eventTable$eventID, 5,8)
+  eventTable$acceptedScientificName <- speciesLegend$acceptedScientificName[match(eventTable$scientificName, 
+                                                                                  speciesLegend$surveyedSpecies)]
+  eventTable$dataType <- "PA"
+  eventTable$taxonKey <- speciesLegend$taxonKey[match(eventTable$acceptedScientificName, speciesLegend$acceptedScientificName)]
+  eventTable$taxa <- focalTaxon$taxa[match(eventTable$taxonKey, focalTaxon$key)]
+  eventTable$taxonKeyProject <- focalTaxon$key[match(eventTable$taxonKey, focalTaxon$key)]
+  eventTable$individualCount[is.na(eventTable$individualCount)] <- 0
   
   
-  # continue only if at least one species is present in ANO
-  if(nrow(ANODataset) > 0) {
-    # Start creating a matrix of species occurrence
-    
-    ANODataset$dataType <- "PA"
-  }
+  # New dataset is ready!
+  newDataset <- st_as_sf(eventTable,          
+                         crs = crs)
+  newDataset <- newDataset %>%
+    dplyr::select(acceptedScientificName, individualCount, geometry, dataType, taxa, year, taxonKeyProject, eventID) %>%
+    filter(!is.na(acceptedScientificName))
   
-  ANODataset <- ANODataset[,c("acceptedScientificName", "individualCount", "geometry", "dataType", "taxa", "year", "taxonKeyProject")]
-  ANODataset <- ANODataset[!is.na(ANODataset$acceptedScientificName),]
-  ANODataset <- st_as_sf(ANODataset, crs = crs)
-  
-  
-  # Remove any duplicated observations from the same year at the same place
-  arrangedData <- ANODataset[order(ANODataset$individualCount, decreasing = TRUE),]
-  newDataset2 <- arrangedData[!duplicated(arrangedData[,c("geometry", "year", "acceptedScientificName")]),]
-  
-  return(ANODataset)
+  saveRDS(newDataset, paste0(tempFolderName,"/", datasetName ,"/processedDataset.RDS"))
+  return(newDataset)
 }

--- a/functions/processCitizenScience.R
+++ b/functions/processCitizenScience.R
@@ -1,0 +1,50 @@
+
+#' @title \emph{processCitizenScience}: Thins out multiple citizen science observations in the same pixel in individual datasets
+
+#' @description Overly intense sampling of citizen science within one pixel creates extreme levels of sampling bias that needs to be calmed down for this process.
+#'
+#' @param dataset The citizen science dataset to be thinned. Should be an sf points data frame.
+#' @param regionGeometry A directory in which to save the data downloaded directly from the source.
+#' @param crs The crs to be used for projecting onto
+#' 
+#' @return A new dataset with excess observations removed.
+#'
+#' @import sf
+#' 
+#' 
+#' 
+processCitizenScience <- function(dataset, regionGeometry, crs, tempFolderName, datasetName) {
+  
+  cat("\tThinning",datasetName, "data\n")
+  
+  dataset$id <- c(1:nrow(dataset))
+  datasetVect <- vect(dataset[,c("acceptedScientificName", "id")])
+  
+  # Import env data and get the right crs
+  e <- ext(vect(regionGeometry))
+  emptyRaster <- rast(e, res = 500, crs = "EPSG:25833 ")
+  emptyRasterConv <- project(emptyRaster, crs)
+  
+  dataCell <- setValues(emptyRasterConv, 1:ncell(emptyRasterConv)) 
+  
+  
+  datasetVect$cell <- extract(dataCell, datasetVect)[,2]
+  datasetFrame <- as.data.frame(datasetVect)
+  dataUnique <- datasetFrame[!duplicated(datasetFrame[,c("acceptedScientificName", "cell")]),]
+  #nbicDataSubset$cell <- extract(dataCell, nbicDataSubset)[,2]
+
+  datasetUnique <- dataset[dataset$id %in% dataUnique$id,names(dataset)[!(names(dataset) %in% "id")]]
+  
+  if (!dir.exists(paste0(tempFolderName,"/", datasetName))) {
+    dir.create(paste0(tempFolderName,"/", datasetName))
+  }
+  
+  newDataset <- datasetUnique[,c("acceptedScientificName", "geometry", "dataType", "taxa", "year", "taxonKeyProject")]
+  newDataset <- st_transform(newDataset, crs)
+  
+  saveRDS(newDataset, paste0(tempFolderName,"/", datasetName ,"/processedDataset.RDS"))
+  
+  return(newDataset)
+  
+  
+}

--- a/functions/processFieldNotesEvent.R
+++ b/functions/processFieldNotesEvent.R
@@ -128,11 +128,7 @@ processFieldNotesEvent <- function(focalEndpoint, tempFolderName, datasetName, r
   
   # Get rid of data before 1991
   eventTableWithOccurrences <- eventTableWithOccurrences[eventTableWithOccurrences$year >= yearToStart,]
-  
-  # Add red list status back in
-  eventTableWithOccurrences$redListStatus <- focalData$redListStatus[match(eventTableWithOccurrences$acceptedScientificName, 
-                                                                           focalData$acceptedScientificName)]
-  
+
   # New dataset is ready!
   newDataset <- st_as_sf(eventTableWithOccurrences,          
                          crs = crs)

--- a/functions/processFieldNotesEvent.R
+++ b/functions/processFieldNotesEvent.R
@@ -133,7 +133,7 @@ processFieldNotesEvent <- function(focalEndpoint, tempFolderName, datasetName, r
   newDataset <- st_as_sf(eventTableWithOccurrences,          
                          crs = crs)
   newDataset <- newDataset %>%
-    dplyr::select(acceptedScientificName, individualCount, geometry, dataType, taxa, year, taxonKeyProject, eventID, redListStatus) %>%
+    dplyr::select(acceptedScientificName, individualCount, geometry, dataType, taxa, year, taxonKeyProject, eventID) %>%
     filter(!is.na(acceptedScientificName))
  
   saveRDS(newDataset, paste0(tempFolderName,"/", datasetName ,"/processedDataset.RDS"))

--- a/functions/processNTNUFreshwater.R
+++ b/functions/processNTNUFreshwater.R
@@ -1,0 +1,145 @@
+
+#' @title \emph{processFieldNotesEvent}: Turns a presence only dataset into a presence absence dataset for surveyed data.
+
+#' @description Some datasets have been reduced by GBIF to presence-only, despite the fact they are in fact presence-absence datastes. This function downloads these datasets directly from the source and adds the absences back in.
+#'
+#' @param focalEndpoint An endpoint through which the original dataset can be downloaded.
+#' @param tempFolderName A directory in which to save the data downloaded directly from the source.
+#' @param datasetName The name of the dataset to be downloaded.
+#' @param regionGeometry An sf object encompassing our region of study, as produced by defineRegion.
+#' @param focalTaxon A dataframe giving the key and names of each taxonomic group we are downloading.
+#' 
+#' @return A new dataset with absences added back in.
+#'
+#' @import sf
+#' 
+#' 
+processNTNUFreshwater <- function(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon,
+                                   crs, coordUncertainty, yearToStart) {
+  
+  # Get the relevant endpoint
+  
+  # Download and unzip file in temp folder
+  #ptions(timeout=100)
+  download.file(focalEndpoint, paste0(tempFolderName,"/", datasetName ,".zip"), mode = "wb")
+  unzip(paste0(tempFolderName,"/", datasetName ,".zip"), exdir = paste0(tempFolderName,"/",  datasetName))
+  
+  # Function to change file names
+  foo = function(x){
+    paste(toupper(substring(x, 1, 1)),
+          tolower(substring(x, 2, nchar(x))),
+          sep = "")
+  }
+  
+  # Load in event and occurrence data
+  events <- read.delim(paste0(tempFolderName,"/", datasetName ,"/event.txt")) %>%
+    filter(coordinateUncertaintyInMeters < coordUncertainty)
+  occurrence <- read.delim(paste0(tempFolderName,"/", datasetName ,"/occurrence.txt"))
+  
+  # Make sure we have a 'year' column
+  if (!("year" %in% colnames(events)) | all(is.na(unique(events$year)))) {
+    if ("eventDate" %in% colnames(occurrence)) {
+      eventTable <- distinct(occurrence[,c("eventID", "eventDate")])
+      eventTable$year <- format(as.Date(eventTable$eventDate), "%Y") 
+      events$year <- eventTable$year[match(events$eventID, eventTable$eventID)]
+    } else if ("eventDate" %in% colnames(events)) {
+      eventTable <- distinct(events[,c("eventID", "eventDate")])
+      events$year <- format(as.Date(eventTable$eventDate), "%Y") 
+    } else {
+      events$year <- NA
+    } }
+  
+  # Now remove anything before start year
+  events <- events %>%
+    filter(year >= yearToStart)
+  occurrence <- occurrence %>%
+    filter(eventID %in% events$eventID)
+  
+  # Get all species surveyed
+  surveyedSpecies <-  unique(occurrence$scientificName)
+  surveyedSpecies <- surveyedSpecies[!is.na(surveyedSpecies)]
+  
+  # Find only eventIDs within our regionGeometry
+  eventLocations <- events %>%
+    filter(!is.na(decimalLatitude) & !is.na(decimalLongitude)) %>%
+    dplyr::select(decimalLatitude, decimalLongitude, eventID, coordinateUncertaintyInMeters, samplingProtocol) %>%
+    distinct()
+  eventLocationsSF <- st_as_sf(eventLocations,                         
+                               coords = c("decimalLongitude", "decimalLatitude"),
+                               crs = "+proj=longlat +ellps=WGS84")
+  eventLocationsSF <- st_transform(eventLocationsSF, crs = crs)
+  eventLocationsSF <- st_intersection(eventLocationsSF, regionGeometry) %>%
+    filter(coordinateUncertaintyInMeters <= coordUncertainty)
+  
+  # At this point we may find that there are no relevant points from this dataset available - 
+  # in this case we want to finish the function early
+  if (nrow(eventLocationsSF) == 0) {
+    return(NULL)
+  }
+  
+  # Get a dates table to match years to events
+  eventDates <- events %>%
+    filter(eventID %in% eventLocationsSF$eventID) %>%
+    dplyr::select(year, eventID) %>%
+    distinct()
+  
+  # Build a species table
+  speciesLegend <- data.frame(surveyedSpecies = surveyedSpecies, 
+                              acceptedScientificName = sapply(surveyedSpecies, FUN = findGBIFName),
+                              taxonKey = sapply(surveyedSpecies, FUN = function(x) {taxaCheck(x, focalTaxon$key)})) %>%
+    filter(!is.na(taxonKey) & !is.na(acceptedScientificName))
+  if (nrow(speciesLegend) == 0) {return(NULL)}
+  
+  
+  # Start constructing table- do this per sampling protocol
+  samplingProtocols <- unique(eventLocationsSF$samplingProtocol)
+  eventList <- lapply(samplingProtocols, FUN = function(sp) {
+    speciesSampled <- unique(occurrence$scientificName[occurrence$samplingProtocol == sp])
+    speciesSampled2 <- speciesSampled[speciesSampled %in% speciesLegend$surveyedSpecies]
+    eventIDsUsed <- unique(eventLocationsSF$eventID[eventLocationsSF$samplingProtocol == sp])
+    if (length(speciesSampled2) == 0) {
+      return(NA)
+    } else {
+      return(expand.grid(scientificName = speciesSampled2, eventID = eventIDsUsed))
+    }
+  })
+  
+  # Remove empty events
+  eventList2 <- eventList[unlist(lapply(eventList, FUN = function(x) {!is.null(nrow(x))}))]
+  
+  eventTable <- do.call(rbind, eventList2)
+  eventTable <- merge(eventTable, eventDates, all.x = TRUE, by = "eventID")
+  
+  # Create an individual count 
+  occurrence$individualCount <- 1
+  
+  # Add in occurrence data, an NA in individualCount column means the species was NOT found in the survey
+  eventTableWithOccurrences <- merge(eventTable, occurrence[,c("eventID", "scientificName", "individualCount")], all.x = TRUE,
+                                     by.x = c("scientificName", "eventID"), by.y = c("scientificName", "eventID"))
+  eventTableWithOccurrences$individualCount[is.na(eventTableWithOccurrences$individualCount)] <- 0
+  eventTableWithOccurrences$geometry <- eventLocationsSF$geometry[match(eventTableWithOccurrences$eventID, eventLocationsSF$eventID)]
+  eventTableWithOccurrences$acceptedScientificName <- speciesLegend$acceptedScientificName[match(eventTableWithOccurrences$scientificName, speciesLegend$surveyedSpecies)]
+  
+  # Add final columns
+  eventTableWithOccurrences$dataType <- "PA"
+  eventTableWithOccurrences$taxonKey <- speciesLegend$taxonKey[match(eventTableWithOccurrences$acceptedScientificName, speciesLegend$acceptedScientificName)]
+  eventTableWithOccurrences$taxa <- focalTaxon$taxa[match(eventTableWithOccurrences$taxonKey, focalTaxon$key)]
+  eventTableWithOccurrences$taxonKeyProject <- focalTaxon$key[match(eventTableWithOccurrences$taxonKey, focalTaxon$key)]
+  
+  # Get rid of data before 1991
+  eventTableWithOccurrences <- eventTableWithOccurrences[eventTableWithOccurrences$year >= yearToStart,]
+  
+  
+  # New dataset is ready!
+  newDataset <- st_as_sf(eventTableWithOccurrences,          
+                         crs = crs)
+  newDataset <- newDataset %>%
+    dplyr::select(acceptedScientificName, individualCount, geometry, dataType, taxa, year, taxonKeyProject, eventID) %>%
+    filter(!is.na(acceptedScientificName)) %>% arrange(desc(individualCount))
+  
+  # Remove any duplicates (species repeatedly sampled at the same event using different protocols)
+  newDataset2 <- newDataset[!duplicated(newDataset[,c("geometry", "acceptedScientificName", "individualCount")]),]
+  
+  saveRDS(newDataset2, paste0(tempFolderName,"/", datasetName ,"/processedDataset.RDS"))
+  return(newDataset2)
+}

--- a/functions/processVannmiljo.R
+++ b/functions/processVannmiljo.R
@@ -1,0 +1,133 @@
+
+#' @title \emph{processFieldNotes}: Turns a presence only dataset into a presence absence dataset for surveyed data.
+
+#' @description Some datasets have been reduced by GBIF to presence-only, despite the fact they are in fact presence-absence datastes. This function downloads these datasets directly from the source and adds the absences back in.
+#'
+#' @param focalEndpoint An endpoint through which the original dataset can be downloaded.
+#' @param tempFolderName A directory in which to save the data downloaded directly from the source.
+#' @param datasetName The name of the dataset to be downloaded.
+#' @param regionGeometry An sf object encompassing our region of study, as produced by defineRegion.
+#' @param focalTaxon A dataframe giving the key and names of each taxonomic group we are downloading.
+#' 
+#' @return A new dataset with absences added back in.
+#'
+#' @import sf
+#' 
+#' 
+#' 
+processVannmiljo <- function(focalEndpoint, tempFolderName, datasetName, regionGeometry, 
+                              focalTaxon, crs, coordUncertainty, yearToStart) {
+  
+  
+  # Get the relevant endpoint
+  
+  # Download and unzip file in temp folder
+  #options(timeout=100)
+  download.file(focalEndpoint, paste0(tempFolderName,"/", datasetName ,".zip"), mode = "wb")
+  unzip(paste0(tempFolderName,"/", datasetName ,".zip"), exdir = paste0(tempFolderName,"/",  datasetName))
+  
+  # Load in occurrence data
+  occurrence <- read.delim(paste0(tempFolderName,"/", datasetName ,"/occurrence.txt"))
+  occurrence <- occurrence[!grepl("Marin", occurrence$samplingProtocol),]
+  occurrence <- occurrence[!grepl("Ukjent", occurrence$samplingProtocol),]
+  
+  # make sure we have a year column
+  if (!("year" %in% colnames(occurrence))) {
+    occurrence$year <- substr(occurrence$eventDate,1,4)
+  }
+  occurrence <- occurrence %>%
+    filter(year >= yearToStart & !is.na(year))
+  
+  # Remove data with bad coord uncertainty
+  if( !is.na(coordUncertainty)) {
+    occurrence <- occurrence %>%
+      filter(coordinateUncertaintyInMeters <= coordUncertainty)
+  }
+
+  
+  # Create surveyed species
+  surveyedSpecies <- unique(occurrence$scientificName[occurrence$taxonRank == ""])
+  surveyedSpecies2 <- str_subset(surveyedSpecies, "^\\w+\\s\\w+$")
+  
+  # Buold a species table
+  speciesLegend <- data.frame(surveyedSpecies = surveyedSpecies2, 
+                              acceptedScientificName = sapply(surveyedSpecies2, FUN = findGBIFName),
+                              taxonKey = sapply(surveyedSpecies2, FUN = function(x) {taxaCheck(x, focalTaxon$key)})) %>%
+    filter(!is.na(taxonKey))
+  
+  # Get the most recent eventID (survey) at each parentEventID (survey)
+  eventIDs <- occurrence[!duplicated(occurrence[,c("eventID", "parentEventID", "year")]),c("eventID", "parentEventID", "year")]
+  arrangedEvents <- eventIDs[order(eventIDs$year, decreasing = TRUE),]
+  newDataset2 <- arrangedEvents[!duplicated(arrangedEvents[,c("parentEventID")]),]
+  
+  # Find only eventIDs within our regionGeometry
+  eventLocations <- occurrence %>%
+    filter(!is.na(decimalLatitude) & !is.na(decimalLongitude) & eventID %in% newDataset2$eventID) %>%
+    dplyr::select(decimalLatitude, decimalLongitude, eventID, samplingProtocol) %>%
+    distinct()
+  eventLocationsSF <- st_as_sf(eventLocations,                         
+                               coords = c("decimalLongitude", "decimalLatitude"),
+                               crs = "+proj=longlat +ellps=WGS84")
+  eventLocationsSF <- st_transform(eventLocationsSF, crs = crs)
+  eventLocationsSF <- st_intersection(eventLocationsSF, regionGeometry)
+  
+  # At this point we may find that there are no relevant points from this dataset available - 
+  # in this case we want to finish the function early
+  if (nrow(eventLocationsSF) == 0) {
+    return(NULL)
+  }
+
+  # Get a dates table to match years to events
+  eventDates <- occurrence %>%
+    dplyr::select(year, eventID) %>%
+    distinct()
+  
+  # Start constructing table- do this per sampling protocol
+  samplingProtocols <- unique(eventLocationsSF$samplingProtocol)
+  eventList <- lapply(samplingProtocols, FUN = function(sp) {
+    speciesSampled <- unique(occurrence$scientificName[occurrence$samplingProtocol == sp])
+    speciesSampled2 <- speciesSampled[speciesSampled %in% speciesLegend$surveyedSpecies]
+    eventIDsUsed <- unique(eventLocationsSF$eventID[eventLocationsSF$samplingProtocol == sp])
+    if (length(speciesSampled2) == 0) {
+      return(NA)
+    } else {
+        return(expand.grid(scientificName = speciesSampled2, eventID = eventIDsUsed))
+      }
+  })
+  
+  # Remove empty events
+  eventList2 <- eventList[unlist(lapply(eventList, FUN = function(x) {!is.null(nrow(x))}))]
+  
+  eventTable <- do.call(rbind, eventList2)
+  eventTable <- merge(eventTable, eventDates, all.x = TRUE, by = "eventID")
+  
+  # Create an individual count 
+  occurrence$individualCount <- 1
+  
+  # Add in occurrence data, an NA in coordinateUncertainy column means the species was NOT found in the survey
+  eventTableWithOccurrences <- merge(eventTable, occurrence[,c("eventID", "scientificName", "individualCount")], all.x = TRUE,
+                                     by.x = c("scientificName", "eventID"), by.y = c("scientificName", "eventID"))
+  eventTableWithOccurrences$individualCount[is.na(eventTableWithOccurrences$individualCount)] <- 0
+  eventTableWithOccurrences$geometry <- eventLocationsSF$geometry[match(eventTableWithOccurrences$eventID, eventLocationsSF$eventID)]
+  eventTableWithOccurrences$acceptedScientificName <- speciesLegend$acceptedScientificName[match(eventTableWithOccurrences$scientificName, speciesLegend$surveyedSpecies)]
+  
+  # Add final columns
+  eventTableWithOccurrences$dataType <- "PA"
+  eventTableWithOccurrences$taxonKey <- speciesLegend$taxonKey[match(eventTableWithOccurrences$acceptedScientificName, speciesLegend$acceptedScientificName)]
+  eventTableWithOccurrences$taxa <- focalTaxon$taxa[match(eventTableWithOccurrences$taxonKey, focalTaxon$key)]
+  eventTableWithOccurrences$taxonKeyProject <- focalTaxon$key[match(eventTableWithOccurrences$taxonKey, focalTaxon$key)]
+  
+  # New dataset is ready!
+  newDataset <- st_as_sf(eventTableWithOccurrences,          
+                         crs = crs)
+  newDataset <- newDataset %>%
+    dplyr::select(acceptedScientificName, individualCount, geometry, dataType, taxa, year, taxonKeyProject) %>%
+    filter(!is.na(acceptedScientificName))
+  
+  # Remove any duplicated observations from the same year at the same place
+  arrangedData <- newDataset[order(newDataset$individualCount, decreasing = TRUE),]
+  newDataset2 <- arrangedData[!duplicated(arrangedData[,c("geometry", "acceptedScientificName")]),]
+  
+  saveRDS(newDataset, paste0(tempFolderName,"/", datasetName ,"/processedDataset.RDS"))
+  return(newDataset)
+}

--- a/masterScript.R
+++ b/masterScript.R
@@ -62,8 +62,6 @@ yearInterval <- NA
 yearInterval <- 2012:2018
 maskCityData <- TRUE
 
-# Indicates whether we want to download the ANOData or use the data from file
-downloadANOData <- FALSE
 
 # If we have already run some code with the same dateAccessed and we want to 
 # re-start the initialisation process:

--- a/pipeline/import/initialiseRepository.R
+++ b/pipeline/import/initialiseRepository.R
@@ -103,7 +103,6 @@ if(file.exists(paste0(folderName,"/controlPars.RDS"))){
                       prior.range = prior.range,
                       prior.sigma = prior.sigma,
                       nSegment = nSegment,
-                      downloadANOData = downloadANOData,
                       speciesOccurrenceThreshold = speciesOccurrenceThreshold,
                       datasetOccurrenceThreshold = datasetOccurrenceThreshold,
                       temporal = temporal,

--- a/pipeline/integration/speciesDataProcessing.R
+++ b/pipeline/integration/speciesDataProcessing.R
@@ -81,7 +81,7 @@ if (file.exists(paste0(folderName, "/metadataSummary.csv"))) {
 }
 speciesData <- speciesData[!is.na(speciesData$processing),]
 
-# Narrow down to known data types and split into data frames
+# Reproject datasets and narrow down to focal region
 projcrs <- "+proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0"
 speciesData2 <- lapply(unique(speciesData$name), FUN  = function(x) {
   GBIFItem <- speciesData[speciesData$name == x,]
@@ -148,7 +148,6 @@ for (ds in seq_along(speciesData2)) {
                               polyphyleticSpecies$taxa[match(newDataset$acceptedScientificName, polyphyleticSpecies$acceptedScientificName)], 
                               newDataset$taxa)
   } 
-  
   
   # convert year to numeric
   newDataset$year <- as.numeric(newDataset$year)
@@ -221,9 +220,14 @@ countedData <- do.call(rbind, lapply(maskedData, FUN = function(x) {
      ds <- st_drop_geometry(x[x$individualCount > 0, "simpleScientificName"])
   } else {ds <- st_drop_geometry(x[,"simpleScientificName"])}
   ds
-})) %>% group_by(simpleScientificName) %>% tally() %>% filter(n > speciesOccurrenceThreshold)
+})) %>% group_by(simpleScientificName) %>% tally()
+
+# Identify species to keep
+speciesToKeep <- countedData[countedData$n > speciesOccurrenceThreshold,"simpleScientificName"]
+nSpeciesRemoved <- nrow(countedData) - nrow(speciesToKeep)
+cat("Removing", nSpeciesRemoved,"species with too few notifications")
 countedData2 <- lapply(maskedData, FUN = function(x2) {
-  ds <- x2[x2$simpleScientificName %in% countedData$simpleScientificName,]
+  ds <- x2[x2$simpleScientificName %in% speciesToKeep$simpleScientificName,]
   ds
 })
 countedData2 <- countedData2[lapply(countedData2,nrow)>0]

--- a/pipeline/integration/utils/defineProcessing.R
+++ b/pipeline/integration/utils/defineProcessing.R
@@ -5,6 +5,7 @@
 # reside in functions and begin with "process".
 
 # 0. Check whether a pre-processed version of this dataset exists
+focalEndpoint <- unique(focalData$DWCEndpoint)
 dataFileName <- paste0(tempFolderName,"/", datasetName ,"/processedDataset.RDS")
 if (file.exists(dataFileName)) {
   cat("\tPre-processed version used\n")
@@ -12,60 +13,64 @@ if (file.exists(dataFileName)) {
   
   # 1. The national insect Monitoring in Norway dataset
 } else if (dataType == "insectMonitoring") {
-  focalEndpoint <- unique(focalData$DWCEndpoint)
   newDataset <- processNationalInsectMonitoring(focalData, focalEndpoint, tempFolderName, crs, coordUncertainty)
   
   # 1b. The national insect Monitoring in Norway dataset sturcture, but for other similar datasets
 } else if (dataType == "insectMonitoringStandard") {
-  focalEndpoint <- metadata$DWCEndpoint[metadata$name == datasetName]
   newDataset <- processInsectMonitoring(focalData, focalEndpoint, tempFolderName, crs, coordUncertainty)
   
   # 2. ANO Data
-} else if (dataType == "ANO") {
-  newDataset <- processANOData(focalData, crs)
+} else if (dataType == "ANOData") {
+  newDataset <- processANOData(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon, crs, yearToStart) 
   
   # 3. Field note data  
 } else if (dataType == "fieldNotes"){
-  focalEndpoint <- metadata$DWCEndpoint[metadata$name == datasetName]
   newDataset <- processFieldNotes(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon, crs, coordUncertainty, yearToStart)
   
   # 4. Field note data  - Oslo and Agder
 } else if (dataType == "fieldNotesOslo"){
-  focalEndpoint <- metadata$DWCEndpoint[metadata$name == datasetName]
   newDataset <- processFieldNotesOslo(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon, crs, 
                                       coordUncertainty, yearToStart)
   
   
   # 5. Field note data (with events table)
 } else if (dataType == "fieldNotesEvent") {
-  focalEndpoint <- unique(focalData$DWCEndpoint)
   newDataset <- processFieldNotesEvent(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon, crs, coordUncertainty, yearToStart)
   
-  # No need to do anything to presence only data (yet) except add individualCount column
+  # 6. NTNU freshwater collection
+} else if (dataType == "NTNUFreshwater") {
+  newDataset <- processNTNUFreshwater(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon, crs, coordUncertainty, yearToStart)
+  
+  # 7. Freshwater fish inventory Norway
 } else if (dataType == "freshwaterFishInventory") {
-  focalEndpoint <- metadata$DWCEndpoint[metadata$name == datasetName]
   newDataset <- processFreshwaterFishInventory(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon, crs, coordUncertainty, yearToStart)
   
   # No need to do anything to presence only data (yet) except add individualCount column
 }else if (dataType == "mareano") {
-  focalEndpoint <- metadata$DWCEndpoint[metadata$name == datasetName]
   newDataset <- processMareano(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon, crs)
   
   # No need to do anything to presence only data (yet) except add individualCount column
 } else if (dataType == "marine1") {
-  focalEndpoint <- metadata$DWCEndpoint[metadata$name == datasetName]
   newDataset <- processMarine1(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon, crs)
   
   # No need to do anything to presence only data (yet) except add individualCount column
 } else if (dataType == "marine2") {
-  focalEndpoint <- metadata$DWCEndpoint[metadata$name == datasetName]
   newDataset <- processMarine2(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon, crs)
   
+  # No need to do anything to presence only data (yet) except add individualCount column
+}else if (dataType == "vannmiljo") {
+  newDataset <- processVannmiljo(focalEndpoint, tempFolderName, datasetName, regionGeometry, focalTaxon, crs, coordUncertainty, yearToStart)
+
   # No need to do anything to presence only data (yet) except add individualCount column
 }else if (dataType == "presenceOnly") {
   focalData$dataType <- "PO"
   newDataset <- focalData[,c("acceptedScientificName", "geometry", "dataType", "taxa", "year", "taxonKeyProject", "redListStatus")]
   newDataset <- st_transform(newDataset, crs)
+  
+} else if (dataType == "citizenScience") {
+  focalData$dataType <- "PO"
+  newDataset <- processCitizenScience(focalData, regionGeometry, '+proj=utm +zone=33 +datum=WGS84 +units=km +no_defs', tempFolderName, datasetName)
+  
 } else {
   focalData$dataType <- "PO"
   newDataset <- focalData[,c("acceptedScientificName", "geometry", "dataType", "taxa", "year", "taxonKeyProject")]
@@ -85,7 +90,7 @@ if ("data.frame" %in% class(newDataset)) {
     newDataset$year <- sapply(newDataset$year, function(x) {x + max(negative_number(yearInterval - x))})
   }
   
-  if (dataType %in% c("presenceOnly", "PO")) {
+  if (dataType %in% c("presenceOnly", "PO", "citizenScience")) {
     arrangedData <- newDataset %>%
       arrange(-year)
   } else {


### PR DESCRIPTION
# Why have changes been made?

- There have been a lot of new datasets added in lately, and here I've added in their respective processing scripts. Additionally, the ANO data is now available on GBIF; and we should download directly from there to maintain consistency. Lastly, the removal of species with less than 50 occurrences has now been moved to earlier in the pipeline, cutting down on unnecessary data storage of less common species.

# What changes have been made?

- data/external/metadataSummary.csv - Includes our new datasets and processing scripts
- functions/processCitizenScience.R, functions/processNTNUFreshwater.R and functions/processVannmiljo.R are all new dataset  prcoessing scripts that do the same as many of the other scripts, but with slight tweaks. They've all been added to pipeline/integration/utils/defineProcessing.R.
- functions/processANOData.R - This does the same thing as importANOData used to, but now that ANO is in GBIF we've shifted this to the processing stage. This is reflected in small changes in masterScript.R and pipeline/import/initialiseRepository.R which remove the downloadANOData parameter.
- pipeline/integration/speciesDataProcessing.R - The removal of species with less than 50 occurrences has been shifted up in the pipeline to this point.

## Additional changes

- functions/processFieldNotesEvent.R - Small bug removed - redListStatus is inserted in defineProcessing and isn't needed here.
